### PR TITLE
Major dashboard UI overhaul: Notion-inspired UX

### DIFF
--- a/web/src/app/(app)/calendar/page.tsx
+++ b/web/src/app/(app)/calendar/page.tsx
@@ -3,5 +3,5 @@
 import { PageShell } from '@/components/page-shell';
 
 export default function CalendarPage() {
-  return <PageShell page="calendar" title="Calendar" subtitle="Your week at a glance" />;
+  return <PageShell page="calendar" title="Schedules" subtitle="Your week at a glance" />;
 }

--- a/web/src/app/(app)/settings/settings-client.tsx
+++ b/web/src/app/(app)/settings/settings-client.tsx
@@ -223,7 +223,7 @@ export function SettingsClient({
                     <p className="text-xl font-bold text-text">
                       {getGreeting(user.name)}
                     </p>
-                    <p className="text-sm text-text-muted font-mono mt-1">
+                    <p className="text-sm text-text-muted mt-1">
                       {user.email}
                     </p>
                   </div>
@@ -234,7 +234,7 @@ export function SettingsClient({
                   <p className="text-[10px] uppercase tracking-widest text-text-muted">
                     Day
                   </p>
-                  <p className="text-4xl font-bold text-text font-mono tabular-nums leading-tight">
+                  <p className="text-4xl font-bold text-text tabular-nums leading-tight">
                     {days}
                   </p>
                 </div>
@@ -277,7 +277,7 @@ export function SettingsClient({
                 <button
                   onClick={handleUpdateTimezone}
                   disabled={updatingTz}
-                  className="text-xs font-mono text-text underline underline-offset-2 hover:opacity-70 transition-opacity disabled:opacity-50"
+                  className="text-xs text-text underline underline-offset-2 hover:opacity-70 transition-opacity disabled:opacity-50"
                 >
                   {updatingTz ? 'Updating...' : 'Update'}
                 </button>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -16,7 +16,7 @@
   --color-success: #00dc82;
   --color-warning: #f5a623;
   --color-danger: #ff4444;
-  --font-sans: "Kefa", "Satoshi", "Inter", ui-sans-serif, system-ui, sans-serif;
+  --font-sans: "Geist", ui-sans-serif, system-ui, sans-serif;
 }
 
 /* ── Theme Overrides (inside @layer theme for cascade priority) ── */
@@ -177,6 +177,31 @@ body {
 .stagger-children > *:nth-child(8) { animation-delay: 350ms; }
 .stagger-children > *:nth-child(9) { animation-delay: 400ms; }
 .stagger-children > *:nth-child(10) { animation-delay: 450ms; }
+
+@keyframes slide-up {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes slide-down {
+  from { opacity: 0; transform: translateY(-8px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes slide-in-right {
+  from { opacity: 0; transform: translateX(8px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+.animate-slide-up {
+  animation: slide-up 0.3s ease-out forwards;
+}
+
+.animate-slide-down {
+  animation: slide-down 0.3s ease-out forwards;
+}
+
+.animate-slide-in-right {
+  animation: slide-in-right 0.3s ease-out forwards;
+}
 
 /* ── Scrollbar ───────────────────────────────────── */
 

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <head>
         <link
-          href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700,900&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700;900&display=swap"
           rel="stylesheet"
         />
       </head>

--- a/web/src/components/configure-toolbar.tsx
+++ b/web/src/components/configure-toolbar.tsx
@@ -7,6 +7,7 @@ import { themes, themeKeys, systemThemeEntry } from '@/lib/themes';
 import { cn } from '@/lib/utils';
 
 const FONT_OPTIONS = [
+  { key: 'geist', name: 'Geist', family: '"Geist", ui-sans-serif, system-ui, sans-serif', href: 'https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap' },
   { key: 'kefa', name: 'Kefa', family: '"Kefa", ui-sans-serif, system-ui, sans-serif', href: '' },
   { key: 'satoshi', name: 'Satoshi', family: '"Satoshi", ui-sans-serif, system-ui, sans-serif', href: 'https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700,900&display=swap' },
   { key: 'inter', name: 'Inter', family: '"Inter", ui-sans-serif, system-ui, sans-serif', href: 'https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap' },
@@ -14,7 +15,6 @@ const FONT_OPTIONS = [
   { key: 'space-grotesk', name: 'Space Grotesk', family: '"Space Grotesk", ui-sans-serif, system-ui, sans-serif', href: 'https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;600;700&display=swap' },
   { key: 'dm-sans', name: 'DM Sans', family: '"DM Sans", ui-sans-serif, system-ui, sans-serif', href: 'https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap' },
   { key: 'outfit', name: 'Outfit', family: '"Outfit", ui-sans-serif, system-ui, sans-serif', href: 'https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700&display=swap' },
-  { key: 'geist', name: 'Geist', family: '"Geist", ui-sans-serif, system-ui, sans-serif', href: 'https://fonts.googleapis.com/css2?family=Geist:wght@400;500;600;700&display=swap' },
   { key: 'ibm-plex', name: 'IBM Plex Sans', family: '"IBM Plex Sans", ui-sans-serif, system-ui, sans-serif', href: 'https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&display=swap' },
   { key: 'source-serif', name: 'Source Serif', family: '"Source Serif 4", Georgia, serif', href: 'https://fonts.googleapis.com/css2?family=Source+Serif+4:wght@400;500;600;700&display=swap' },
   { key: 'system', name: 'System', family: 'ui-sans-serif, system-ui, -apple-system, sans-serif', href: '' },
@@ -39,7 +39,7 @@ function applyFont(family: string) {
 export function ConfigureToolbar() {
   const { isConfigMode, toggleConfigMode, config, setNavMode } = useDashboardConfig();
   const { theme, setTheme } = useTheme();
-  const [activeFont, setActiveFont] = useState('kefa');
+  const [activeFont, setActiveFont] = useState('geist');
 
   useEffect(() => {
     const stored = localStorage.getItem(FONT_STORAGE_KEY);

--- a/web/src/components/context-menu.tsx
+++ b/web/src/components/context-menu.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+
+interface ContextMenuItem {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+  variant?: 'default' | 'danger';
+  divider?: boolean;
+}
+
+interface ContextMenuProps {
+  items: ContextMenuItem[];
+  children: React.ReactNode;
+}
+
+export type { ContextMenuItem };
+
+export function ContextMenu({ items, children }: ContextMenuProps) {
+  const [open, setOpen] = useState(false);
+  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    // Calculate position, adjusting for viewport overflow
+    const menuWidth = 200;
+    const menuHeight = items.length * 36 + 8; // approximate
+    let x = e.clientX;
+    let y = e.clientY;
+
+    if (x + menuWidth > window.innerWidth) {
+      x = e.clientX - menuWidth;
+    }
+    if (y + menuHeight > window.innerHeight) {
+      y = e.clientY - menuHeight;
+    }
+
+    setPosition({ x, y });
+    setOpen(true);
+  }, [items.length]);
+
+  // Close on click outside, escape, scroll
+  useEffect(() => {
+    if (!open) return;
+    const close = () => setOpen(false);
+    const handleEscape = (e: KeyboardEvent) => { if (e.key === 'Escape') close(); };
+    document.addEventListener('click', close);
+    document.addEventListener('keydown', handleEscape);
+    document.addEventListener('scroll', close, true);
+    return () => {
+      document.removeEventListener('click', close);
+      document.removeEventListener('keydown', handleEscape);
+      document.removeEventListener('scroll', close, true);
+    };
+  }, [open]);
+
+  return (
+    <>
+      <div onContextMenu={handleContextMenu}>
+        {children}
+      </div>
+      {open && (
+        <div
+          ref={menuRef}
+          className="fixed z-[60] min-w-[180px] rounded-xl border border-border bg-surface shadow-2xl py-1 animate-scale-in"
+          style={{ left: position.x, top: position.y }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {items.map((item, i) => (
+            <div key={i}>
+              {item.divider && <div className="my-1 border-t border-border/40" />}
+              <button
+                onClick={() => { item.onClick(); setOpen(false); }}
+                className={`w-full flex items-center gap-2.5 px-3 py-2 text-sm transition-colors ${
+                  item.variant === 'danger'
+                    ? 'text-text-muted hover:text-danger hover:bg-danger/5'
+                    : 'text-text-muted hover:text-text hover:bg-surface-hover'
+                }`}
+              >
+                {item.icon && <span className="opacity-60">{item.icon}</span>}
+                {item.label}
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </>
+  );
+}

--- a/web/src/components/global-quick-add.tsx
+++ b/web/src/components/global-quick-add.tsx
@@ -6,12 +6,61 @@ import { api } from '@/lib/convex-api';
 import { useDashboardConfig } from '@/lib/dashboard-config';
 import { cn } from '@/lib/utils';
 
-type QuickAddType = 'task' | 'idea' | 'thought';
+type QuickAddType = 'task' | 'idea' | 'thought' | 'win' | 'reminder';
 
-const QUICK_ADD_OPTIONS: { type: QuickAddType; label: string }[] = [
-  { type: 'task', label: 'Task' },
-  { type: 'idea', label: 'Idea' },
-  { type: 'thought', label: 'Thought' },
+const QUICK_ADD_OPTIONS: { type: QuickAddType; label: string; icon: React.ReactNode }[] = [
+  {
+    type: 'task',
+    label: 'Task',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+        <polyline points="22 4 12 14.01 9 11.01" />
+      </svg>
+    ),
+  },
+  {
+    type: 'idea',
+    label: 'Idea',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <line x1="12" y1="2" x2="12" y2="6" />
+        <line x1="12" y1="18" x2="12" y2="22" />
+        <line x1="4.93" y1="4.93" x2="7.76" y2="7.76" />
+        <line x1="16.24" y1="16.24" x2="19.07" y2="19.07" />
+        <line x1="2" y1="12" x2="6" y2="12" />
+        <line x1="18" y1="12" x2="22" y2="12" />
+      </svg>
+    ),
+  },
+  {
+    type: 'thought',
+    label: 'Thought',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+      </svg>
+    ),
+  },
+  {
+    type: 'win',
+    label: 'Win',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+      </svg>
+    ),
+  },
+  {
+    type: 'reminder',
+    label: 'Reminder',
+    icon: (
+      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+        <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+      </svg>
+    ),
+  },
 ];
 
 const ACTIONABILITY_OPTIONS = [
@@ -29,7 +78,7 @@ function Toast({ message, onDone }: { message: string; onDone: () => void }) {
   }, [onDone]);
 
   return (
-    <div className="fixed bottom-6 right-6 z-[60] bg-surface border border-border px-4 py-2 text-xs font-medium text-success uppercase tracking-wide animate-fade-in">
+    <div className="fixed bottom-6 right-6 z-[60] bg-surface border border-border rounded-xl px-4 py-2.5 text-xs font-medium text-success animate-fade-in shadow-lg">
       {message}
     </div>
   );
@@ -53,9 +102,7 @@ function TaskQuickForm({ onDone }: { onDone: () => void }) {
     if (!title.trim() || saving) return;
     setSaving(true);
     try {
-      const args: { title: string; dueDate?: string } = {
-        title: title.trim(),
-      };
+      const args: { title: string; dueDate?: string } = { title: title.trim() };
       if (dueDate) args.dueDate = dueDate;
       await createTask(args);
       onDone();
@@ -74,18 +121,18 @@ function TaskQuickForm({ onDone }: { onDone: () => void }) {
         placeholder="Task title"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        className="w-full border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none"
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none"
       />
       <input
         type="date"
         value={dueDate}
         onChange={(e) => setDueDate(e.target.value)}
-        className="w-full border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
       />
       <button
         type="submit"
         disabled={!title.trim() || saving}
-        className="w-full bg-text text-bg py-2 text-xs font-medium uppercase tracking-wide transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
+        className="w-full bg-text text-bg rounded-lg py-2 text-xs font-medium transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
       >
         {saving ? 'Adding...' : 'Add Task'}
       </button>
@@ -111,9 +158,7 @@ function IdeaQuickForm({ onDone }: { onDone: () => void }) {
     if (!content.trim() || saving) return;
     setSaving(true);
     try {
-      const args: { content: string; actionability?: string } = {
-        content: content.trim(),
-      };
+      const args: { content: string; actionability?: string } = { content: content.trim() };
       if (actionability) args.actionability = actionability;
       await createIdea(args);
       onDone();
@@ -132,24 +177,22 @@ function IdeaQuickForm({ onDone }: { onDone: () => void }) {
         value={content}
         onChange={(e) => setContent(e.target.value)}
         rows={3}
-        className="w-full border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none resize-none"
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none resize-none"
       />
       <select
         value={actionability}
         onChange={(e) => setActionability(e.target.value)}
-        className="w-full border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
       >
         <option value="">Actionability (optional)</option>
         {ACTIONABILITY_OPTIONS.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
         ))}
       </select>
       <button
         type="submit"
         disabled={!content.trim() || saving}
-        className="w-full bg-text text-bg py-2 text-xs font-medium uppercase tracking-wide transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
+        className="w-full bg-text text-bg rounded-lg py-2 text-xs font-medium transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
       >
         {saving ? 'Adding...' : 'Add Idea'}
       </button>
@@ -175,9 +218,7 @@ function ThoughtQuickForm({ onDone }: { onDone: () => void }) {
     if (!content.trim() || saving) return;
     setSaving(true);
     try {
-      const args: { content: string; title?: string } = {
-        content: content.trim(),
-      };
+      const args: { content: string; title?: string } = { content: content.trim() };
       if (title.trim()) args.title = title.trim();
       await createThought(args);
       onDone();
@@ -196,21 +237,125 @@ function ThoughtQuickForm({ onDone }: { onDone: () => void }) {
         value={content}
         onChange={(e) => setContent(e.target.value)}
         rows={3}
-        className="w-full border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none resize-none"
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none resize-none"
       />
       <input
         type="text"
         placeholder="Title (optional)"
         value={title}
         onChange={(e) => setTitle(e.target.value)}
-        className="w-full border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none"
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none"
       />
       <button
         type="submit"
         disabled={!content.trim() || saving}
-        className="w-full bg-text text-bg py-2 text-xs font-medium uppercase tracking-wide transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
+        className="w-full bg-text text-bg rounded-lg py-2 text-xs font-medium transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
       >
         {saving ? 'Adding...' : 'Add Thought'}
+      </button>
+    </form>
+  );
+}
+
+// ── Win Form ──────────────────────────────────────────────
+
+function WinQuickForm({ onDone }: { onDone: () => void }) {
+  const [content, setContent] = useState('');
+  const [saving, setSaving] = useState(false);
+  const createWin = useMutation(api.wins.create);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!content.trim() || saving) return;
+    setSaving(true);
+    try {
+      await createWin({ content: content.trim() });
+      onDone();
+    } catch (err) {
+      console.error('Failed to create win:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="What did you accomplish?"
+        value={content}
+        onChange={(e) => setContent(e.target.value)}
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none"
+      />
+      <button
+        type="submit"
+        disabled={!content.trim() || saving}
+        className="w-full bg-text text-bg rounded-lg py-2 text-xs font-medium transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
+      >
+        {saving ? 'Adding...' : 'Add Win'}
+      </button>
+    </form>
+  );
+}
+
+// ── Reminder Form ─────────────────────────────────────────
+
+function ReminderQuickForm({ onDone }: { onDone: () => void }) {
+  const [title, setTitle] = useState('');
+  const [scheduledAt, setScheduledAt] = useState('');
+  const [saving, setSaving] = useState(false);
+  const createReminder = useMutation(api.reminders.create);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !scheduledAt || saving) return;
+    setSaving(true);
+    try {
+      await createReminder({
+        title: title.trim(),
+        scheduledAt: new Date(scheduledAt).getTime(),
+      });
+      onDone();
+    } catch (err) {
+      console.error('Failed to create reminder:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-3">
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="Reminder title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:border-accent focus:outline-none"
+      />
+      <input
+        type="datetime-local"
+        value={scheduledAt}
+        onChange={(e) => setScheduledAt(e.target.value)}
+        className="w-full border border-border bg-bg rounded-lg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+      />
+      <button
+        type="submit"
+        disabled={!title.trim() || !scheduledAt || saving}
+        className="w-full bg-text text-bg rounded-lg py-2 text-xs font-medium transition-colors hover:bg-accent-hover disabled:opacity-30 disabled:pointer-events-none"
+      >
+        {saving ? 'Adding...' : 'Add Reminder'}
       </button>
     </form>
   );
@@ -247,16 +392,30 @@ export function GlobalQuickAdd() {
   useEffect(() => {
     if (!open) return;
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') close();
+      if (e.key === 'Escape') {
+        if (selectedType) {
+          setSelectedType(null);
+        } else {
+          close();
+        }
+      }
     };
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, close]);
+  }, [open, selectedType, close]);
 
   const handleSuccess = useCallback((label: string) => {
     close();
     setToast(`${label} added`);
   }, [close]);
+
+  const FORM_MAP: Record<QuickAddType, React.ReactNode> = {
+    task: <TaskQuickForm onDone={() => handleSuccess('Task')} />,
+    idea: <IdeaQuickForm onDone={() => handleSuccess('Idea')} />,
+    thought: <ThoughtQuickForm onDone={() => handleSuccess('Thought')} />,
+    win: <WinQuickForm onDone={() => handleSuccess('Win')} />,
+    reminder: <ReminderQuickForm onDone={() => handleSuccess('Reminder')} />,
+  };
 
   return (
     <>
@@ -278,9 +437,9 @@ export function GlobalQuickAdd() {
             }
           }}
           className={cn(
-            'flex h-8 w-8 items-center justify-center border border-border bg-surface text-text transition-all duration-150',
-            'hover:bg-surface-hover hover:border-text-muted/40',
-            open && 'bg-surface-hover border-text-muted/40 rotate-45',
+            'flex h-8 w-8 items-center justify-center rounded-full border border-border bg-surface text-text transition-all duration-200',
+            'hover:bg-surface-hover hover:border-text-muted/40 hover:scale-105',
+            open && 'bg-surface-hover border-text-muted/40 rotate-45 scale-105',
           )}
           aria-label="Quick add"
         >
@@ -299,50 +458,49 @@ export function GlobalQuickAdd() {
           </svg>
         </button>
 
-        {/* Dropdown / Form popover */}
-        {open && (
-          <div className="absolute top-10 right-0 w-64 border border-border bg-surface shadow-lg">
-            {/* Type selector tabs */}
-            <div className="flex border-b border-border">
-              {QUICK_ADD_OPTIONS.map(({ type, label }) => (
+        {/* Dropdown */}
+        {open && !selectedType && (
+          <div className="absolute top-10 right-0 w-52 border border-border bg-surface rounded-xl shadow-xl animate-scale-in overflow-hidden">
+            <div className="px-3 py-2.5 border-b border-border/40">
+              <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted">
+                Quick Add
+              </span>
+            </div>
+            <div className="py-1">
+              {QUICK_ADD_OPTIONS.map(({ type, label, icon }) => (
                 <button
                   key={type}
                   onClick={() => setSelectedType(type)}
-                  className={cn(
-                    'flex-1 px-3 py-2.5 text-xs font-medium uppercase tracking-wide transition-colors',
-                    selectedType === type
-                      ? 'text-text border-b-2 border-text'
-                      : 'text-text-muted hover:text-text',
-                  )}
+                  className="flex items-center gap-3 w-full px-3 py-2 text-sm text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
                 >
+                  <span className="opacity-60">{icon}</span>
                   {label}
                 </button>
               ))}
             </div>
+          </div>
+        )}
 
-            {/* Form area */}
-            {selectedType === null && (
-              <div className="px-4 py-6 text-center">
-                <p className="text-xs text-text-muted uppercase tracking-wide">
-                  Select a type above
-                </p>
-              </div>
-            )}
-            {selectedType === 'task' && (
-              <div className="p-4">
-                <TaskQuickForm onDone={() => handleSuccess('Task')} />
-              </div>
-            )}
-            {selectedType === 'idea' && (
-              <div className="p-4">
-                <IdeaQuickForm onDone={() => handleSuccess('Idea')} />
-              </div>
-            )}
-            {selectedType === 'thought' && (
-              <div className="p-4">
-                <ThoughtQuickForm onDone={() => handleSuccess('Thought')} />
-              </div>
-            )}
+        {/* Form popover */}
+        {open && selectedType && (
+          <div className="absolute top-10 right-0 w-72 border border-border bg-surface rounded-xl shadow-xl animate-scale-in overflow-hidden">
+            {/* Header with back button */}
+            <div className="flex items-center gap-2 px-3 py-2.5 border-b border-border/40">
+              <button
+                onClick={() => setSelectedType(null)}
+                className="flex h-5 w-5 items-center justify-center rounded-md text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+              >
+                <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                  <polyline points="15 18 9 12 15 6" />
+                </svg>
+              </button>
+              <span className="text-xs font-medium text-text">
+                New {QUICK_ADD_OPTIONS.find(o => o.type === selectedType)?.label}
+              </span>
+            </div>
+            <div className="p-4">
+              {FORM_MAP[selectedType]}
+            </div>
           </div>
         )}
       </div>

--- a/web/src/components/goal-detail-modal.tsx
+++ b/web/src/components/goal-detail-modal.tsx
@@ -1,0 +1,548 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/lib/convex-api';
+import type { Id } from '@/lib/convex-api';
+import { cn } from '@/lib/utils';
+
+type GoalStatus = 'active' | 'completed' | 'dropped';
+
+const STATUS_OPTIONS: { value: GoalStatus; label: string; color: string; dot: string }[] = [
+  { value: 'active', label: 'Active', color: 'text-accent', dot: 'bg-accent' },
+  { value: 'completed', label: 'Completed', color: 'text-success', dot: 'bg-success' },
+  { value: 'dropped', label: 'Dropped', color: 'text-text-muted', dot: 'bg-text-muted' },
+];
+
+const HEALTH_CONFIG: Record<string, { label: string; color: string }> = {
+  on_track: { label: 'On Track', color: 'text-success' },
+  at_risk: { label: 'At Risk', color: 'text-warning' },
+  off_track: { label: 'Off Track', color: 'text-danger' },
+  unknown: { label: 'No Data', color: 'text-text-muted' },
+};
+
+export function GoalDetailModal({
+  goalId,
+  onClose,
+}: {
+  goalId: Id<'goals'>;
+  onClose: () => void;
+}) {
+  const goalDetail = useQuery(api.goals.get, { id: goalId });
+  const health = useQuery(api.goals.health, { id: goalId });
+  const updateGoal = useMutation(api.goals.update);
+  const removeGoal = useMutation(api.goals.remove);
+  const completeTask = useMutation(api.tasks.complete);
+  const createTask = useMutation(api.tasks.create);
+
+  const [titleValue, setTitleValue] = useState('');
+  const [descriptionValue, setDescriptionValue] = useState('');
+  const [quarterValue, setQuarterValue] = useState('');
+  const [targetDateValue, setTargetDateValue] = useState('');
+  const [statusOpen, setStatusOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [addingTask, setAddingTask] = useState(false);
+  const [newTaskTitle, setNewTaskTitle] = useState('');
+
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+  const newTaskInputRef = useRef<HTMLInputElement>(null);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const initializedRef = useRef(false);
+
+  // Initialize local state from goal data
+  useEffect(() => {
+    if (goalDetail && !initializedRef.current) {
+      setTitleValue(goalDetail.title);
+      setDescriptionValue(goalDetail.description ?? '');
+      setQuarterValue(goalDetail.quarter ?? '');
+      setTargetDateValue(goalDetail.targetDate ?? '');
+      initializedRef.current = true;
+    }
+  }, [goalDetail]);
+
+  // Reset initialized flag when goalId changes
+  useEffect(() => {
+    initializedRef.current = false;
+  }, [goalId]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Prevent body scroll
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }, []);
+
+  // Close status dropdown on outside click
+  useEffect(() => {
+    if (!statusOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (statusRef.current && !statusRef.current.contains(e.target as Node)) {
+        setStatusOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [statusOpen]);
+
+  // Auto-resize description textarea
+  const autoResize = useCallback(() => {
+    if (descriptionRef.current) {
+      descriptionRef.current.style.height = 'auto';
+      descriptionRef.current.style.height = `${descriptionRef.current.scrollHeight}px`;
+    }
+  }, []);
+
+  useEffect(() => { autoResize(); }, [descriptionValue, autoResize]);
+
+  const handleTitleBlur = useCallback(async () => {
+    setEditingTitle(false);
+    if (titleValue.trim() && goalDetail && titleValue.trim() !== goalDetail.title) {
+      try {
+        await updateGoal({ id: goalId, title: titleValue.trim() });
+      } catch (err) {
+        console.error('Failed to update goal title:', err);
+      }
+    }
+  }, [titleValue, goalDetail, goalId, updateGoal]);
+
+  const handleDescriptionBlur = useCallback(async () => {
+    if (goalDetail && descriptionValue !== (goalDetail.description ?? '')) {
+      try {
+        await updateGoal({ id: goalId, description: descriptionValue });
+      } catch (err) {
+        console.error('Failed to update goal description:', err);
+      }
+    }
+  }, [descriptionValue, goalDetail, goalId, updateGoal]);
+
+  const handleStatusSelect = useCallback(async (status: GoalStatus) => {
+    setStatusOpen(false);
+    try {
+      await updateGoal({ id: goalId, status });
+    } catch (err) {
+      console.error('Failed to update goal status:', err);
+    }
+  }, [goalId, updateGoal]);
+
+  const handleQuarterBlur = useCallback(async () => {
+    if (goalDetail && quarterValue !== (goalDetail.quarter ?? '')) {
+      try {
+        await updateGoal({ id: goalId, quarter: quarterValue });
+      } catch (err) {
+        console.error('Failed to update goal quarter:', err);
+      }
+    }
+  }, [quarterValue, goalDetail, goalId, updateGoal]);
+
+  const handleTargetDateBlur = useCallback(async () => {
+    if (goalDetail && targetDateValue !== (goalDetail.targetDate ?? '')) {
+      try {
+        await updateGoal({ id: goalId, targetDate: targetDateValue });
+      } catch (err) {
+        console.error('Failed to update goal target date:', err);
+      }
+    }
+  }, [targetDateValue, goalDetail, goalId, updateGoal]);
+
+  const handleCompleteTask = useCallback(async (taskId: Id<'tasks'>) => {
+    try {
+      await completeTask({ id: taskId });
+    } catch (err) {
+      console.error('Failed to complete task:', err);
+    }
+  }, [completeTask]);
+
+  const handleAddTask = useCallback(async () => {
+    if (!newTaskTitle.trim()) return;
+    try {
+      await createTask({ title: newTaskTitle.trim(), goalId });
+      setNewTaskTitle('');
+      setAddingTask(false);
+    } catch (err) {
+      console.error('Failed to add task:', err);
+    }
+  }, [createTask, newTaskTitle, goalId]);
+
+  const handleDelete = useCallback(async () => {
+    try {
+      await removeGoal({ id: goalId });
+      onClose();
+    } catch (err) {
+      console.error('Failed to delete goal:', err);
+    }
+  }, [removeGoal, goalId, onClose]);
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  }, [onClose]);
+
+  if (!goalDetail) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        onClick={handleBackdropClick}
+      >
+        <div className="rounded-2xl bg-surface border border-border shadow-2xl max-w-2xl w-full mx-4 p-8 animate-scale-in">
+          <div className="flex items-center justify-center">
+            <div className="h-6 w-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const currentStatus = STATUS_OPTIONS.find((o) => o.value === goalDetail.status) ?? STATUS_OPTIONS[0];
+  const healthInfo = HEALTH_CONFIG[health?.status ?? 'unknown'];
+  const createdDate = new Date(goalDetail._creationTime).toLocaleDateString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="rounded-2xl bg-surface border border-border shadow-2xl max-w-2xl w-full mx-4 flex flex-col max-h-[80vh] overflow-hidden animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-end px-4 py-3 border-b border-border/50">
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left panel -- title, description, tasks */}
+          <div className="flex-[3] p-6 overflow-y-auto space-y-5">
+            {/* Title */}
+            <div>
+              {editingTitle ? (
+                <input
+                  ref={titleInputRef}
+                  type="text"
+                  value={titleValue}
+                  onChange={(e) => setTitleValue(e.target.value)}
+                  onBlur={handleTitleBlur}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      (e.target as HTMLInputElement).blur();
+                    }
+                  }}
+                  className="w-full bg-transparent text-lg font-semibold text-text focus:outline-none"
+                  autoFocus
+                />
+              ) : (
+                <h2
+                  className="text-lg font-semibold text-text cursor-text hover:text-accent/80 transition-colors"
+                  onClick={() => {
+                    setEditingTitle(true);
+                    setTimeout(() => titleInputRef.current?.focus(), 0);
+                  }}
+                >
+                  {titleValue || goalDetail.title}
+                </h2>
+              )}
+            </div>
+
+            {/* Description */}
+            <textarea
+              ref={descriptionRef}
+              value={descriptionValue}
+              onChange={(e) => {
+                setDescriptionValue(e.target.value);
+                autoResize();
+              }}
+              onBlur={handleDescriptionBlur}
+              placeholder="Add description..."
+              rows={3}
+              className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none resize-none leading-relaxed"
+            />
+
+            {/* Linked Tasks */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">
+                  Linked Tasks ({goalDetail.tasks.length})
+                </span>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setAddingTask(true);
+                    setTimeout(() => newTaskInputRef.current?.focus(), 0);
+                  }}
+                  className="text-[11px] font-medium text-accent hover:text-accent-hover transition-colors"
+                >
+                  + Add task
+                </button>
+              </div>
+
+              {/* Add task inline */}
+              {addingTask && (
+                <div className="flex items-center gap-2">
+                  <input
+                    ref={newTaskInputRef}
+                    type="text"
+                    value={newTaskTitle}
+                    onChange={(e) => setNewTaskTitle(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleAddTask();
+                      }
+                      if (e.key === 'Escape') {
+                        setAddingTask(false);
+                        setNewTaskTitle('');
+                      }
+                    }}
+                    placeholder="Task title..."
+                    className="flex-1 bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none border-b border-border focus:border-accent transition-colors py-1"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleAddTask}
+                    disabled={!newTaskTitle.trim()}
+                    className="text-xs font-medium text-accent hover:text-accent-hover disabled:opacity-40 transition-colors"
+                  >
+                    Add
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setAddingTask(false); setNewTaskTitle(''); }}
+                    className="text-xs text-text-muted hover:text-text transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+
+              {goalDetail.tasks.length === 0 && !addingTask ? (
+                <p className="text-xs text-text-muted italic">No linked tasks</p>
+              ) : (
+                <div className="space-y-0.5">
+                  {/* Todo tasks first */}
+                  {goalDetail.tasks
+                    .filter((t) => t.status === 'todo')
+                    .map((task) => (
+                      <div
+                        key={task._id}
+                        className="flex items-center gap-2 text-sm py-1.5 group/task"
+                      >
+                        <button
+                          type="button"
+                          onClick={() => handleCompleteTask(task._id)}
+                          className="h-4 w-4 rounded border border-border hover:border-accent shrink-0 transition-colors flex items-center justify-center group-hover/task:border-accent/60"
+                          aria-label="Complete task"
+                        />
+                        <span className="flex-1 min-w-0 truncate text-text">
+                          {task.title}
+                        </span>
+                        {task.dueDate && (
+                          <span className="text-xs text-text-muted ml-auto font-mono shrink-0">
+                            {task.dueDate}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  {/* Done tasks */}
+                  {goalDetail.tasks
+                    .filter((t) => t.status === 'done')
+                    .map((task) => (
+                      <div
+                        key={task._id}
+                        className="flex items-center gap-2 text-sm py-1.5"
+                      >
+                        <div className="h-4 w-4 rounded border border-success/40 bg-success/20 shrink-0 flex items-center justify-center">
+                          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="text-success">
+                            <polyline points="20 6 9 17 4 12" />
+                          </svg>
+                        </div>
+                        <span className="flex-1 min-w-0 truncate text-text-muted line-through">
+                          {task.title}
+                        </span>
+                        {task.dueDate && (
+                          <span className="text-xs text-text-muted/60 ml-auto font-mono shrink-0">
+                            {task.dueDate}
+                          </span>
+                        )}
+                      </div>
+                    ))}
+                  {/* Dropped tasks */}
+                  {goalDetail.tasks
+                    .filter((t) => t.status === 'dropped')
+                    .map((task) => (
+                      <div
+                        key={task._id}
+                        className="flex items-center gap-2 text-sm py-1.5"
+                      >
+                        <div className="h-4 w-4 rounded border border-text-muted/30 bg-text-muted/10 shrink-0" />
+                        <span className="flex-1 min-w-0 truncate text-text-muted line-through">
+                          {task.title}
+                        </span>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right panel -- metadata sidebar */}
+          <div className="flex-[2] border-l border-border bg-bg-subtle p-5 overflow-y-auto space-y-4">
+            {/* Status */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Status</span>
+              <div className="relative" ref={statusRef}>
+                <button
+                  type="button"
+                  onClick={() => setStatusOpen((prev) => !prev)}
+                  className="flex items-center gap-2 w-full text-left text-sm rounded-lg px-2.5 py-2 hover:bg-surface-hover transition-colors"
+                >
+                  <span className={cn('h-2 w-2 rounded-full shrink-0', currentStatus.dot)} />
+                  <span className={currentStatus.color}>{currentStatus.label}</span>
+                </button>
+                {statusOpen && (
+                  <div className="absolute z-50 top-full left-0 mt-1 w-full border border-border bg-surface rounded-lg shadow-xl overflow-hidden">
+                    {STATUS_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => handleStatusSelect(opt.value)}
+                        className={cn(
+                          'w-full text-left px-3 py-2 text-xs transition-colors hover:bg-surface-hover flex items-center gap-2',
+                          goalDetail.status === opt.value && 'bg-accent/10 font-medium',
+                        )}
+                      >
+                        <span className={cn('h-2 w-2 rounded-full shrink-0', opt.dot)} />
+                        <span className={opt.color}>{opt.label}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Quarter */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Quarter</span>
+              <input
+                type="text"
+                value={quarterValue}
+                onChange={(e) => setQuarterValue(e.target.value)}
+                onBlur={handleQuarterBlur}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    (e.target as HTMLInputElement).blur();
+                  }
+                }}
+                placeholder="e.g. 2026-Q1"
+                className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none px-2.5 py-2 rounded-lg hover:bg-surface-hover focus:bg-surface-hover transition-colors"
+              />
+            </div>
+
+            {/* Target Date */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Target Date</span>
+              <input
+                type="date"
+                value={targetDateValue}
+                onChange={(e) => setTargetDateValue(e.target.value)}
+                onBlur={handleTargetDateBlur}
+                className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none px-2.5 py-2 rounded-lg hover:bg-surface-hover focus:bg-surface-hover transition-colors [color-scheme:dark]"
+              />
+            </div>
+
+            {/* Health */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Health</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-lg">
+                {health ? (
+                  <>
+                    <span className={cn(
+                      'h-2 w-2 rounded-full shrink-0',
+                      health.status === 'on_track' && 'bg-success',
+                      health.status === 'at_risk' && 'bg-warning',
+                      health.status === 'off_track' && 'bg-danger',
+                      health.status === 'unknown' && 'bg-text-muted',
+                    )} />
+                    <span className={healthInfo.color}>{healthInfo.label}</span>
+                    <span className="text-xs text-text-muted ml-auto">
+                      {health.doneTasks}/{health.totalTasks} tasks
+                    </span>
+                  </>
+                ) : (
+                  <span className="text-text-muted">Loading...</span>
+                )}
+              </div>
+            </div>
+
+            {/* Created */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Created</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm text-text-muted rounded-lg">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-50 shrink-0">
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+                <span>{createdDate}</span>
+              </div>
+            </div>
+
+            {/* Delete */}
+            <div className="pt-2 border-t border-border/40">
+              {!confirmDelete ? (
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(true)}
+                  className="w-full text-center text-xs text-text-muted hover:text-danger py-2 rounded-lg hover:bg-surface-hover transition-colors"
+                >
+                  Delete goal
+                </button>
+              ) : (
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="flex-1 text-xs font-medium text-danger bg-danger/10 hover:bg-danger/20 py-1.5 rounded-lg transition-colors"
+                  >
+                    Confirm Delete
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDelete(false)}
+                    className="text-xs text-text-muted hover:text-text py-1.5 px-3 rounded-lg hover:bg-surface-hover transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/goal-form.tsx
+++ b/web/src/components/goal-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { Button } from '@/components/ui/button';
@@ -14,6 +14,27 @@ export function GoalForm({ onDone }: { onDone?: () => void }) {
   const [quarter, setQuarter] = useState('');
 
   const createGoal = useMutation(api.goals.create);
+
+  function closeModal() {
+    setOpen(false);
+    setTitle('');
+    setDescription('');
+    setTargetDate('');
+    setQuarter('');
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -30,11 +51,7 @@ export function GoalForm({ onDone }: { onDone?: () => void }) {
 
       await createGoal(args);
 
-      setTitle('');
-      setDescription('');
-      setTargetDate('');
-      setQuarter('');
-      setOpen(false);
+      closeModal();
       onDone?.();
     } catch (err) {
       console.error('Failed to create goal:', err);
@@ -52,66 +69,77 @@ export function GoalForm({ onDone }: { onDone?: () => void }) {
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="rounded-lg border border-border bg-surface p-4 space-y-3"
+    <div
+      className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+      onClick={closeModal}
     >
-      <input
-        type="text"
-        placeholder="Goal title"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        autoFocus
-        className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
-      />
+      <div
+        className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text">New Goal</h2>
+          <button
+            type="button"
+            onClick={closeModal}
+            className="text-text-muted hover:text-text transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
 
-      <textarea
-        placeholder="Description (optional)"
-        value={description}
-        onChange={(e) => setDescription(e.target.value)}
-        rows={2}
-        className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
-      />
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="text"
+            placeholder="Goal title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            autoFocus
+            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
 
-      <div className="grid grid-cols-2 gap-3">
-        <input
-          type="date"
-          value={targetDate}
-          onChange={(e) => setTargetDate(e.target.value)}
-          placeholder="Target date"
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
-        />
-        <select
-          value={quarter}
-          onChange={(e) => setQuarter(e.target.value)}
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
-        >
-          <option value="">Quarter (optional)</option>
-          <option value="2026-Q1">2026-Q1</option>
-          <option value="2026-Q2">2026-Q2</option>
-          <option value="2026-Q3">2026-Q3</option>
-          <option value="2026-Q4">2026-Q4</option>
-        </select>
+          <textarea
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={2}
+            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
+          />
+
+          <div className="grid grid-cols-2 gap-3">
+            <input
+              type="date"
+              value={targetDate}
+              onChange={(e) => setTargetDate(e.target.value)}
+              placeholder="Target date"
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+            />
+            <select
+              value={quarter}
+              onChange={(e) => setQuarter(e.target.value)}
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+            >
+              <option value="">Quarter (optional)</option>
+              <option value="2026-Q1">2026-Q1</option>
+              <option value="2026-Q2">2026-Q2</option>
+              <option value="2026-Q3">2026-Q3</option>
+              <option value="2026-Q4">2026-Q4</option>
+            </select>
+          </div>
+
+          <div className="flex gap-2">
+            <Button type="submit" disabled={loading || !title.trim()}>
+              {loading ? 'Creating...' : 'Create Goal'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={closeModal}>
+              Cancel
+            </Button>
+          </div>
+        </form>
       </div>
-
-      <div className="flex gap-2">
-        <Button type="submit" disabled={loading || !title.trim()}>
-          {loading ? 'Creating...' : 'Create Goal'}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={() => {
-            setOpen(false);
-            setTitle('');
-            setDescription('');
-            setTargetDate('');
-            setQuarter('');
-          }}
-        >
-          Cancel
-        </Button>
-      </div>
-    </form>
+    </div>
   );
 }

--- a/web/src/components/header-nav.tsx
+++ b/web/src/components/header-nav.tsx
@@ -21,10 +21,9 @@ const allPages: Record<string, { label: string }> = {
   journal: { label: 'Journal' },
   ideas: { label: 'Ideas' },
   thoughts: { label: 'Thoughts' },
-  plan: { label: 'Plan' },
   reviews: { label: 'Reviews' },
   resources: { label: 'Resources' },
-  calendar: { label: 'Calendar' },
+  calendar: { label: 'Schedules' },
 };
 
 /* ── SVG icon components ─────────────────────────────────── */

--- a/web/src/components/hover-actions-menu.tsx
+++ b/web/src/components/hover-actions-menu.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+
+export interface HoverAction {
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+  variant?: 'default' | 'danger';
+}
+
+interface HoverActionsMenuProps {
+  actions: HoverAction[];
+}
+
+export function HoverActionsMenu({ actions }: HoverActionsMenuProps) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        close();
+      }
+    }
+
+    function handleEscape(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        close();
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open, close]);
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((prev) => !prev);
+        }}
+        className={`h-6 w-6 flex items-center justify-center rounded-md transition-all duration-100 ${
+          open
+            ? 'opacity-100 bg-surface-hover text-text'
+            : 'opacity-0 group-hover:opacity-100 text-text-muted hover:bg-surface-hover hover:text-text'
+        }`}
+        aria-label="Actions"
+      >
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <circle cx="12" cy="5" r="2" />
+          <circle cx="12" cy="12" r="2" />
+          <circle cx="12" cy="19" r="2" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full z-50 mt-1 min-w-[160px] rounded-xl border border-border bg-surface shadow-xl overflow-hidden animate-scale-in"
+          onClick={(e) => e.stopPropagation()}
+        >
+          {actions.map((action, idx) => (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => {
+                action.onClick();
+                close();
+              }}
+              className={`w-full flex items-center gap-2 px-3 py-2 text-sm transition-colors ${
+                action.variant === 'danger'
+                  ? 'text-danger hover:bg-danger/10'
+                  : 'text-text hover:bg-surface-hover'
+              }`}
+            >
+              {action.icon && (
+                <span className="flex-shrink-0 w-4 h-4 flex items-center justify-center opacity-60">
+                  {action.icon}
+                </span>
+              )}
+              {action.label}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/idea-detail-modal.tsx
+++ b/web/src/components/idea-detail-modal.tsx
@@ -1,0 +1,402 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/lib/convex-api';
+import type { Doc, Id } from '@/lib/convex-api';
+import { cn } from '@/lib/utils';
+
+type ActionabilityLevel = 'high' | 'medium' | 'low';
+
+const ACTIONABILITY_OPTIONS: { value: ActionabilityLevel; label: string; color: string }[] = [
+  { value: 'high', label: 'High', color: 'text-success' },
+  { value: 'medium', label: 'Medium', color: 'text-warning' },
+  { value: 'low', label: 'Low', color: 'text-text-muted' },
+];
+
+export function IdeaDetailModal({
+  idea,
+  allIdeas,
+  onClose,
+  onSelectIdea,
+}: {
+  idea: Doc<'ideas'>;
+  allIdeas?: Doc<'ideas'>[];
+  onClose: () => void;
+  onSelectIdea?: (id: Id<'ideas'>) => void;
+}) {
+  const updateIdea = useMutation(api.ideas.update);
+  const removeIdea = useMutation(api.ideas.remove);
+  const promoteIdea = useMutation(api.ideas.promote);
+
+  const [contentValue, setContentValue] = useState(idea.content);
+  const [nextStepValue, setNextStepValue] = useState(idea.nextStep ?? '');
+  const [actionability, setActionability] = useState(idea.actionability);
+  const [actionabilityOpen, setActionabilityOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [promoteOpen, setPromoteOpen] = useState(false);
+  const [promoteTitle, setPromoteTitle] = useState('');
+  const [promoting, setPromoting] = useState(false);
+  const [promotedProjectId, setPromotedProjectId] = useState<Id<'projects'> | null>(
+    idea.projectId ?? null,
+  );
+
+  const contentRef = useRef<HTMLTextAreaElement>(null);
+  const actionabilityRef = useRef<HTMLDivElement>(null);
+
+  // Sync state if idea changes from outside
+  useEffect(() => {
+    setContentValue(idea.content);
+    setNextStepValue(idea.nextStep ?? '');
+    setActionability(idea.actionability);
+  }, [idea.content, idea.nextStep, idea.actionability]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Prevent body scroll
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }, []);
+
+  // Close actionability dropdown on outside click
+  useEffect(() => {
+    if (!actionabilityOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (actionabilityRef.current && !actionabilityRef.current.contains(e.target as Node)) {
+        setActionabilityOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [actionabilityOpen]);
+
+  // Auto-resize textarea
+  const autoResize = useCallback(() => {
+    if (contentRef.current) {
+      contentRef.current.style.height = 'auto';
+      contentRef.current.style.height = `${contentRef.current.scrollHeight}px`;
+    }
+  }, []);
+
+  useEffect(() => { autoResize(); }, [contentValue, autoResize]);
+
+  const handleContentBlur = useCallback(async () => {
+    if (contentValue.trim() && contentValue !== idea.content) {
+      try {
+        await updateIdea({ id: idea._id, content: contentValue.trim() });
+      } catch (err) {
+        console.error('Failed to update idea content:', err);
+      }
+    }
+  }, [contentValue, idea.content, idea._id, updateIdea]);
+
+  const handleNextStepBlur = useCallback(async () => {
+    if (nextStepValue !== (idea.nextStep ?? '')) {
+      try {
+        await updateIdea({ id: idea._id, nextStep: nextStepValue });
+      } catch (err) {
+        console.error('Failed to update idea next step:', err);
+      }
+    }
+  }, [nextStepValue, idea.nextStep, idea._id, updateIdea]);
+
+  const handleActionabilitySelect = useCallback(async (level: ActionabilityLevel) => {
+    setActionability(level);
+    setActionabilityOpen(false);
+    try {
+      await updateIdea({ id: idea._id, actionability: level });
+    } catch (err) {
+      console.error('Failed to update idea actionability:', err);
+    }
+  }, [idea._id, updateIdea]);
+
+  const handleDelete = useCallback(async () => {
+    try {
+      await removeIdea({ id: idea._id });
+      onClose();
+    } catch (err) {
+      console.error('Failed to delete idea:', err);
+    }
+  }, [removeIdea, idea._id, onClose]);
+
+  const handlePromote = useCallback(async () => {
+    if (!promoteTitle.trim()) return;
+    setPromoting(true);
+    try {
+      const result = await promoteIdea({ id: idea._id, projectTitle: promoteTitle.trim() });
+      if (result?.project?._id) {
+        setPromotedProjectId(result.project._id);
+      }
+      setPromoteOpen(false);
+      setPromoteTitle('');
+    } catch (err) {
+      console.error('Failed to promote idea:', err);
+    } finally {
+      setPromoting(false);
+    }
+  }, [promoteIdea, idea._id, promoteTitle]);
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  }, [onClose]);
+
+  const createdDate = new Date(idea._creationTime).toLocaleDateString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  const currentActionability = ACTIONABILITY_OPTIONS.find((o) => o.value === actionability);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="rounded-2xl bg-surface border border-border shadow-2xl max-w-2xl w-full mx-4 flex flex-col max-h-[80vh] overflow-hidden animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-end px-4 py-3 border-b border-border/50">
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left panel -- content */}
+          <div className="flex-[3] p-6 overflow-y-auto">
+            <textarea
+              ref={contentRef}
+              value={contentValue}
+              onChange={(e) => {
+                setContentValue(e.target.value);
+                autoResize();
+              }}
+              onBlur={handleContentBlur}
+              placeholder="Add content..."
+              rows={4}
+              className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none resize-none leading-relaxed"
+            />
+          </div>
+
+          {/* Right panel -- metadata */}
+          <div className="flex-[2] border-l border-border bg-bg-subtle p-5 overflow-y-auto space-y-4">
+            {/* Actionability */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Actionability</span>
+              <div className="relative" ref={actionabilityRef}>
+                <button
+                  type="button"
+                  onClick={() => setActionabilityOpen((prev) => !prev)}
+                  className="flex items-center gap-2 w-full text-left text-sm rounded-lg px-2.5 py-2 hover:bg-surface-hover transition-colors"
+                >
+                  <span className={cn(
+                    'h-2 w-2 rounded-full shrink-0',
+                    currentActionability?.value === 'high' && 'bg-success',
+                    currentActionability?.value === 'medium' && 'bg-warning',
+                    currentActionability?.value === 'low' && 'bg-text-muted',
+                    !currentActionability && 'bg-text-muted/30',
+                  )} />
+                  <span className={currentActionability ? 'text-text' : 'text-text-muted'}>
+                    {currentActionability?.label ?? 'Unset'}
+                  </span>
+                </button>
+                {actionabilityOpen && (
+                  <div className="absolute z-50 top-full left-0 mt-1 w-full border border-border bg-surface rounded-lg shadow-xl overflow-hidden">
+                    {ACTIONABILITY_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => handleActionabilitySelect(opt.value)}
+                        className={cn(
+                          'w-full text-left px-3 py-2 text-xs transition-colors hover:bg-surface-hover flex items-center gap-2',
+                          actionability === opt.value && 'bg-accent/10 font-medium',
+                        )}
+                      >
+                        <span className={cn(
+                          'h-2 w-2 rounded-full shrink-0',
+                          opt.value === 'high' && 'bg-success',
+                          opt.value === 'medium' && 'bg-warning',
+                          opt.value === 'low' && 'bg-text-muted',
+                        )} />
+                        <span className={opt.color}>{opt.label}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Next Step */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Next Step</span>
+              <input
+                type="text"
+                value={nextStepValue}
+                onChange={(e) => setNextStepValue(e.target.value)}
+                onBlur={handleNextStepBlur}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.preventDefault();
+                    (e.target as HTMLInputElement).blur();
+                  }
+                }}
+                placeholder="Define next step..."
+                className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none px-2.5 py-2 rounded-lg hover:bg-surface-hover focus:bg-surface-hover transition-colors"
+              />
+            </div>
+
+            {/* Created */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Created</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm text-text-muted rounded-lg">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-50 shrink-0">
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+                <span>{createdDate}</span>
+              </div>
+            </div>
+
+            {/* Promote to Project */}
+            <div className="pt-2 border-t border-border/40 space-y-2">
+              {promotedProjectId ? (
+                <div className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-lg bg-success/5 border border-success/20">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-success shrink-0">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                  <span className="text-xs text-success">Promoted to project</span>
+                </div>
+              ) : !promoteOpen ? (
+                <button
+                  type="button"
+                  onClick={() => setPromoteOpen(true)}
+                  className="w-full text-center text-xs font-medium text-accent hover:text-accent-hover py-2 rounded-lg hover:bg-accent/10 transition-colors"
+                >
+                  Promote to Project
+                </button>
+              ) : (
+                <div className="space-y-2">
+                  <input
+                    type="text"
+                    value={promoteTitle}
+                    onChange={(e) => setPromoteTitle(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handlePromote();
+                      }
+                    }}
+                    placeholder="Project title..."
+                    autoFocus
+                    className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none px-2.5 py-2 rounded-lg border border-border focus:border-accent transition-colors"
+                  />
+                  <div className="flex gap-2">
+                    <button
+                      type="button"
+                      onClick={handlePromote}
+                      disabled={promoting || !promoteTitle.trim()}
+                      className="flex-1 text-xs font-medium text-bg bg-accent hover:bg-accent-hover disabled:opacity-50 py-1.5 rounded-lg transition-colors"
+                    >
+                      {promoting ? 'Creating...' : 'Create Project'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => { setPromoteOpen(false); setPromoteTitle(''); }}
+                      className="text-xs text-text-muted hover:text-text py-1.5 px-3 rounded-lg hover:bg-surface-hover transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            {/* Related Ideas */}
+            {allIdeas && allIdeas.length > 0 && (() => {
+              const related = allIdeas.filter(
+                (i) => i._id !== idea._id && i.actionability === idea.actionability,
+              );
+              if (related.length === 0) return null;
+              return (
+                <div className="pt-2 border-t border-border/40 space-y-1.5">
+                  <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">
+                    Related Ideas ({related.length})
+                  </span>
+                  <div className="space-y-1">
+                    {related.slice(0, 5).map((relatedIdea) => (
+                      <button
+                        key={relatedIdea._id}
+                        type="button"
+                        onClick={() => onSelectIdea?.(relatedIdea._id)}
+                        className="w-full text-left text-xs text-text-muted hover:text-text py-1.5 px-2.5 rounded-lg hover:bg-surface-hover transition-colors truncate block"
+                      >
+                        {relatedIdea.content.length > 60
+                          ? `${relatedIdea.content.slice(0, 60)}...`
+                          : relatedIdea.content}
+                      </button>
+                    ))}
+                    {related.length > 5 && (
+                      <span className="text-[10px] text-text-muted/60 px-2.5">
+                        +{related.length - 5} more
+                      </span>
+                    )}
+                  </div>
+                </div>
+              );
+            })()}
+
+            {/* Delete */}
+            <div className="pt-2 border-t border-border/40">
+              {!confirmDelete ? (
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(true)}
+                  className="w-full text-center text-xs text-text-muted hover:text-danger py-2 rounded-lg hover:bg-surface-hover transition-colors"
+                >
+                  Delete idea
+                </button>
+              ) : (
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="flex-1 text-xs font-medium text-danger bg-danger/10 hover:bg-danger/20 py-1.5 rounded-lg transition-colors"
+                  >
+                    Confirm Delete
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDelete(false)}
+                    className="text-xs text-text-muted hover:text-text py-1.5 px-3 rounded-lg hover:bg-surface-hover transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/idea-form.tsx
+++ b/web/src/components/idea-form.tsx
@@ -1,17 +1,38 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { Button } from '@/components/ui/button';
 
 export function IdeaForm() {
+  const [open, setOpen] = useState(false);
   const [content, setContent] = useState('');
   const [actionability, setActionability] = useState<string>('medium');
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const createIdea = useMutation(api.ideas.create);
+
+  function closeModal() {
+    setOpen(false);
+    setContent('');
+    setActionability('medium');
+    setError(null);
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -26,8 +47,7 @@ export function IdeaForm() {
         actionability,
       });
 
-      setContent('');
-      setActionability('medium');
+      closeModal();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Something went wrong');
     } finally {
@@ -35,33 +55,69 @@ export function IdeaForm() {
     }
   }
 
+  if (!open) {
+    return (
+      <Button variant="primary" onClick={() => setOpen(true)}>
+        + Add Idea
+      </Button>
+    );
+  }
+
   return (
-    <form onSubmit={handleSubmit} className="space-y-3">
-      <textarea
-        value={content}
-        onChange={(e) => setContent(e.target.value)}
-        placeholder="What's on your mind?"
-        rows={3}
-        className="w-full resize-none rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
-      />
+    <div
+      className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+      onClick={closeModal}
+    >
+      <div
+        className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text">New Idea</h2>
+          <button
+            type="button"
+            onClick={closeModal}
+            className="text-text-muted hover:text-text transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
 
-      <div className="flex items-center gap-3">
-        <select
-          value={actionability}
-          onChange={(e) => setActionability(e.target.value)}
-          className="rounded-md border border-border bg-bg px-3 py-1.5 text-sm text-text focus:border-accent focus:outline-none"
-        >
-          <option value="high">High</option>
-          <option value="medium">Medium</option>
-          <option value="low">Low</option>
-        </select>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="What's on your mind?"
+            rows={3}
+            autoFocus
+            className="w-full resize-none rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
 
-        <Button type="submit" disabled={submitting || !content.trim()}>
-          {submitting ? 'Adding...' : 'Add Idea'}
-        </Button>
+          <div className="flex items-center gap-3">
+            <select
+              value={actionability}
+              onChange={(e) => setActionability(e.target.value)}
+              className="rounded-lg border border-border bg-bg px-3 py-1.5 text-sm text-text focus:border-accent focus:outline-none"
+            >
+              <option value="high">High</option>
+              <option value="medium">Medium</option>
+              <option value="low">Low</option>
+            </select>
+
+            <Button type="submit" disabled={submitting || !content.trim()}>
+              {submitting ? 'Adding...' : 'Add Idea'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={closeModal}>
+              Cancel
+            </Button>
+          </div>
+
+          {error && <p className="text-xs text-danger">{error}</p>}
+        </form>
       </div>
-
-      {error && <p className="text-xs text-danger">{error}</p>}
-    </form>
+    </div>
   );
 }

--- a/web/src/components/journal-form.tsx
+++ b/web/src/components/journal-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { Button } from '@/components/ui/button';
@@ -20,6 +20,27 @@ export function JournalForm({ onDone }: { onDone?: () => void }) {
 
   const upsertJournal = useMutation(api.journals.upsert);
 
+  function closeModal() {
+    setOpen(false);
+    setMit('');
+    setP1('');
+    setP2('');
+    setNotes('');
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setLoading(true);
@@ -35,11 +56,7 @@ export function JournalForm({ onDone }: { onDone?: () => void }) {
 
       await upsertJournal(args);
 
-      setMit('');
-      setP1('');
-      setP2('');
-      setNotes('');
-      setOpen(false);
+      closeModal();
       onDone?.();
     } catch (err) {
       console.error('Failed to save journal:', err);
@@ -57,81 +74,92 @@ export function JournalForm({ onDone }: { onDone?: () => void }) {
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="rounded-lg border border-border bg-surface p-4 space-y-3"
+    <div
+      className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+      onClick={closeModal}
     >
-      <div>
-        <label className="mb-1 block text-xs font-medium text-text-muted">
-          MIT (Most Important Task)
-        </label>
-        <input
-          type="text"
-          placeholder="What is the one thing you must do today?"
-          value={mit}
-          onChange={(e) => setMit(e.target.value)}
-          autoFocus
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
-        />
-      </div>
+      <div
+        className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text">Today&apos;s Journal Entry</h2>
+          <button
+            type="button"
+            onClick={closeModal}
+            className="text-text-muted hover:text-text transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
 
-      <div>
-        <label className="mb-1 block text-xs font-medium text-text-muted">
-          P1 (Priority 1)
-        </label>
-        <input
-          type="text"
-          placeholder="Second priority"
-          value={p1}
-          onChange={(e) => setP1(e.target.value)}
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
-        />
-      </div>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-muted">
+              MIT (Most Important Task)
+            </label>
+            <input
+              type="text"
+              placeholder="What is the one thing you must do today?"
+              value={mit}
+              onChange={(e) => setMit(e.target.value)}
+              autoFocus
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+            />
+          </div>
 
-      <div>
-        <label className="mb-1 block text-xs font-medium text-text-muted">
-          P2 (Priority 2)
-        </label>
-        <input
-          type="text"
-          placeholder="Third priority"
-          value={p2}
-          onChange={(e) => setP2(e.target.value)}
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
-        />
-      </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-muted">
+              P1 (Priority 1)
+            </label>
+            <input
+              type="text"
+              placeholder="Second priority"
+              value={p1}
+              onChange={(e) => setP1(e.target.value)}
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+            />
+          </div>
 
-      <div>
-        <label className="mb-1 block text-xs font-medium text-text-muted">
-          Notes
-        </label>
-        <textarea
-          placeholder="Thoughts, reflections, anything..."
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          rows={4}
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
-        />
-      </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-muted">
+              P2 (Priority 2)
+            </label>
+            <input
+              type="text"
+              placeholder="Third priority"
+              value={p2}
+              onChange={(e) => setP2(e.target.value)}
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+            />
+          </div>
 
-      <div className="flex gap-2">
-        <Button type="submit" disabled={loading}>
-          {loading ? 'Saving...' : 'Save Entry'}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={() => {
-            setOpen(false);
-            setMit('');
-            setP1('');
-            setP2('');
-            setNotes('');
-          }}
-        >
-          Cancel
-        </Button>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-muted">
+              Notes
+            </label>
+            <textarea
+              placeholder="Thoughts, reflections, anything..."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              rows={4}
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
+            />
+          </div>
+
+          <div className="flex gap-2">
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving...' : 'Save Entry'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={closeModal}>
+              Cancel
+            </Button>
+          </div>
+        </form>
       </div>
-    </form>
+    </div>
   );
 }

--- a/web/src/components/main-content.tsx
+++ b/web/src/components/main-content.tsx
@@ -43,7 +43,7 @@ export function MainContent({ children }: { children: React.ReactNode }) {
         isFullHeight ? 'h-screen' : 'min-h-screen overflow-y-auto',
         isHeader
           ? (isConfigMode ? 'mt-[5.75rem]' : 'mt-14')
-          : (expanded ? 'ml-52' : 'ml-14'),
+          : (expanded ? 'ml-56' : 'ml-14'),
       )}
     >
       <ConfigureToolbar />

--- a/web/src/components/nav.tsx
+++ b/web/src/components/nav.tsx
@@ -9,40 +9,41 @@ import { api } from '@/lib/convex-api';
 import { cn } from '@/lib/utils';
 import { useDashboardConfig } from '@/lib/dashboard-config';
 import { HeaderNav } from './header-nav';
-import { LogoMark, LogoHorizontal } from './theme-logo';
+import { LogoMark } from './theme-logo';
 import { NAV_MARKS } from './nav-marks';
 import { SearchTrigger } from './search-modal';
-import { GatewayStatusIndicator } from './ai-agent/gateway-status-indicator';
 
-const allPages: Record<string, { label: string; abbr: string }> = {
+
+const allPages: Record<string, { label: string; abbr: string; category?: string }> = {
   'life-coach': { label: 'Life Coach', abbr: 'Lc' },
-  today: { label: 'Today', abbr: 'To' },
-  tasks: { label: 'Tasks', abbr: 'Ta' },
-  projects: { label: 'Projects', abbr: 'Pr' },
-  goals: { label: 'Compass', abbr: 'Co' },
-  journal: { label: 'Journal', abbr: 'Jo' },
-  ideas: { label: 'Ideas', abbr: 'Id' },
-  thoughts: { label: 'Thoughts', abbr: 'Th' },
-  plan: { label: 'Plan', abbr: 'Pl' },
-  reviews: { label: 'Reviews', abbr: 'Re' },
-  resources: { label: 'Resources', abbr: 'Rs' },
-  calendar: { label: 'Calendar', abbr: 'Ca' },
+  today: { label: 'Today', abbr: 'To', category: 'Daily' },
+  tasks: { label: 'Tasks', abbr: 'Ta', category: 'Daily' },
+  journal: { label: 'Journal', abbr: 'Jo', category: 'Daily' },
+  projects: { label: 'Projects', abbr: 'Pr', category: 'Work' },
+  goals: { label: 'Compass', abbr: 'Co', category: 'Work' },
+  ideas: { label: 'Ideas', abbr: 'Id', category: 'Capture' },
+  thoughts: { label: 'Thoughts', abbr: 'Th', category: 'Capture' },
+  resources: { label: 'Resources', abbr: 'Rs', category: 'Capture' },
+  reviews: { label: 'Reviews', abbr: 'Re', category: 'Reflect' },
+  calendar: { label: 'Schedules', abbr: 'Sc', category: 'Reflect' },
 };
 
+const CATEGORY_ORDER = ['Daily', 'Work', 'Capture', 'Reflect'];
 
 const STORAGE_KEY = 'lifeos-nav-expanded';
 
 export function Nav() {
   const pathname = usePathname();
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(true);
   const [mounted, setMounted] = useState(false);
   const { config, isConfigMode, toggleConfigMode, togglePageVisibility, setNavOrder } = useDashboardConfig();
   const [dragKey, setDragKey] = useState<string | null>(null);
   const [dragOverKey, setDragOverKey] = useState<string | null>(null);
+  const [hovered, setHovered] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    if (stored === 'true') setExpanded(true);
+    if (stored === 'false') setExpanded(false);
     setMounted(true);
   }, []);
 
@@ -72,29 +73,76 @@ export function Nav() {
         hidden: false,
       }));
 
+  // Group nav links by category
+  const grouped: { category: string | null; items: typeof navLinks }[] = [];
+  if (!isConfigMode) {
+    // Life Coach has no category — render it first standalone
+    const lifeCoach = navLinks.filter(l => l.key === 'life-coach');
+    const rest = navLinks.filter(l => l.key !== 'life-coach');
+
+    if (lifeCoach.length > 0) {
+      grouped.push({ category: null, items: lifeCoach });
+    }
+
+    for (const cat of CATEGORY_ORDER) {
+      const items = rest.filter(l => allPages[l.key]?.category === cat);
+      if (items.length > 0) {
+        grouped.push({ category: cat, items });
+      }
+    }
+    // Uncategorized remainder
+    const catSet = new Set(CATEGORY_ORDER);
+    const uncategorized = rest.filter(l => !allPages[l.key]?.category || !catSet.has(allPages[l.key]!.category!));
+    if (uncategorized.length > 0) {
+      grouped.push({ category: null, items: uncategorized });
+    }
+  }
+
+  const showExpanded = expanded || hovered;
+
   return (
     <nav
+      onMouseEnter={() => { if (!expanded) setHovered(true); }}
+      onMouseLeave={() => setHovered(false)}
       className={cn(
-        'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-border bg-bg transition-all duration-200',
-        expanded ? 'w-52' : 'w-14',
+        'fixed inset-y-0 left-0 z-40 flex flex-col border-r border-border/60 bg-bg transition-all duration-200',
+        showExpanded ? 'w-56' : 'w-14',
       )}
     >
-      {/* Logo area */}
+      {/* Logo + toggle */}
       <div
         className={cn(
-          'flex h-14 shrink-0 items-center border-b border-border',
-          expanded ? 'justify-between px-4' : 'justify-center',
+          'flex h-14 shrink-0 items-center',
+          showExpanded ? 'justify-between px-4' : 'justify-center',
         )}
       >
-        {expanded ? (
+        {showExpanded ? (
           <>
-            <LogoMark size={28} className="animate-fade-in" />
+            <div className="flex items-center gap-2.5">
+              <LogoMark size={24} className="opacity-80" />
+              <span className="text-sm font-semibold text-text tracking-tight">LifeOS</span>
+            </div>
             <button
               onClick={toggle}
-              className="flex h-7 w-7 shrink-0 items-center justify-center text-text-muted transition-colors hover:text-text font-mono text-xs"
-              title="Collapse sidebar"
+              className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md text-text-muted transition-colors hover:bg-surface-hover hover:text-text"
+              title={expanded ? 'Collapse sidebar' : 'Pin sidebar'}
             >
-              &larr;
+              {/* Notion-style toggle icon */}
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                {expanded ? (
+                  <>
+                    <rect x="3" y="3" width="18" height="18" rx="3" />
+                    <line x1="9" y1="3" x2="9" y2="21" />
+                    <polyline points="14 9 12 12 14 15" />
+                  </>
+                ) : (
+                  <>
+                    <rect x="3" y="3" width="18" height="18" rx="3" />
+                    <line x1="9" y1="3" x2="9" y2="21" />
+                    <polyline points="12 9 14 12 12 15" />
+                  </>
+                )}
+              </svg>
             </button>
           </>
         ) : (
@@ -103,183 +151,251 @@ export function Nav() {
             className="flex shrink-0 items-center justify-center transition-colors hover:opacity-70"
             title="Expand sidebar"
           >
-            <LogoMark size={28} />
+            <LogoMark size={24} />
           </button>
         )}
       </div>
 
       {/* Main links */}
-      <div className="flex flex-1 flex-col gap-0.5 overflow-y-auto px-2 pt-4">
-        {navLinks.map(({ key, href, label, abbr, hidden }, index) => {
-          const isActive = pathname === href || pathname.startsWith(href + '/');
-
-          return (
-            <div
-              key={key}
-              className={cn(
-                'relative flex items-center',
-                isConfigMode && dragOverKey === key && 'border-t-2 border-text',
+      <div className="flex flex-1 flex-col overflow-y-auto px-2.5 pt-2 pb-2">
+        {isConfigMode ? (
+          // Config mode: flat list with drag handles (no categories)
+          <div className="flex flex-col gap-0.5">
+            {navLinks.map(({ key, href, label, abbr, hidden }) => {
+              const isActive = pathname === href || pathname.startsWith(href + '/');
+              return (
+                <NavItem
+                  key={key}
+                  itemKey={key}
+                  href={href}
+                  label={label}
+                  abbr={abbr}
+                  hidden={hidden}
+                  isActive={isActive}
+                  showExpanded={showExpanded}
+                  isConfigMode={isConfigMode}
+                  mounted={mounted}
+                  index={0}
+                  dragKey={dragKey}
+                  dragOverKey={dragOverKey}
+                  setDragKey={setDragKey}
+                  setDragOverKey={setDragOverKey}
+                  config={config}
+                  setNavOrder={setNavOrder}
+                  togglePageVisibility={togglePageVisibility}
+                />
+              );
+            })}
+          </div>
+        ) : (
+          // Normal mode: grouped by category
+          grouped.map((group, gi) => (
+            <div key={group.category ?? `g-${gi}`} className="mb-1">
+              {group.category && showExpanded && (
+                <div className="px-2 pt-3 pb-1.5 first:pt-0">
+                  <span className="text-[10px] font-semibold uppercase tracking-widest text-text-muted/50">
+                    {group.category}
+                  </span>
+                </div>
               )}
-              draggable={isConfigMode}
-              onDragStart={(e) => {
-                setDragKey(key);
-                e.dataTransfer.effectAllowed = 'move';
-              }}
-              onDragOver={(e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = 'move';
-                setDragOverKey(key);
-              }}
-              onDragLeave={() => setDragOverKey(null)}
-              onDrop={(e) => {
-                e.preventDefault();
-                setDragOverKey(null);
-                if (!dragKey || dragKey === key) return;
-                const order = [...config.navOrder];
-                const fromIdx = order.indexOf(dragKey);
-                const toIdx = order.indexOf(key);
-                if (fromIdx === -1 || toIdx === -1) return;
-                order.splice(fromIdx, 1);
-                order.splice(toIdx, 0, dragKey);
-                setNavOrder(order);
-                setDragKey(null);
-              }}
-              onDragEnd={() => { setDragKey(null); setDragOverKey(null); }}
-            >
-              {/* Drag grip in config mode */}
-              {isConfigMode && expanded && (
-                <span className="flex items-center justify-center w-5 shrink-0 cursor-grab text-text-muted/40 hover:text-text-muted">
-                  <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor">
-                    <circle cx="3" cy="2" r="1" /><circle cx="7" cy="2" r="1" />
-                    <circle cx="3" cy="5" r="1" /><circle cx="7" cy="5" r="1" />
-                    <circle cx="3" cy="8" r="1" /><circle cx="7" cy="8" r="1" />
-                  </svg>
-                </span>
+              {!showExpanded && gi > 0 && group.category && (
+                <div className="mx-auto my-2 w-5 border-t border-border/40" />
               )}
-              <Link
-                href={href}
-                title={expanded ? undefined : label}
-                className={cn(
-                  'group relative flex h-9 items-center transition-all duration-150 flex-1',
-                  expanded ? (isConfigMode ? 'px-1 gap-2 rounded-lg' : 'px-3 gap-3 rounded-lg') : 'justify-center w-10 mx-auto rounded-md',
-                  hidden && 'opacity-40',
-                  isActive
-                    ? 'text-text'
-                    : 'text-text-muted hover:text-text',
-                  isConfigMode && dragKey === key && 'opacity-30',
-                )}
-                style={
-                  expanded && mounted && !isConfigMode
-                    ? { animationDelay: `${index * 30}ms` }
-                    : undefined
-                }
-                onClick={isConfigMode ? (e) => e.preventDefault() : undefined}
-              >
-                {/* Active dot indicator */}
-                {isActive && (
-                  <div className="absolute left-0 top-1/2 -translate-y-1/2 w-1 h-1 rounded-full bg-text" />
-                )}
-                {(() => {
-                  if (key === 'life-coach') {
-                    return expanded ? (
-                      <span className="flex items-center gap-2.5 text-sm font-medium animate-slide-in group/lc relative">
-                        <img src="/openclaw-icon.png" alt="Life Coach" className="shrink-0 size-4 rounded-sm" />
-                        {label}
-                        <span className="absolute left-0 bottom-full mb-1 z-50 hidden group-hover/lc:block bg-surface border border-border rounded px-2 py-1 text-[10px] text-text-muted whitespace-nowrap shadow-lg pointer-events-auto">
-                          Powered by <span onClick={(e) => { e.preventDefault(); e.stopPropagation(); window.open('https://openclaw.ai/', '_blank'); }} className="text-accent hover:underline cursor-pointer">OpenClaw</span>
-                        </span>
-                      </span>
-                    ) : (
-                      <span className="relative group/lc">
-                        <img src="/openclaw-icon.png" alt="Life Coach" className="shrink-0 size-4 rounded-sm" />
-                        <span className="absolute left-full ml-2 top-1/2 -translate-y-1/2 z-50 hidden group-hover/lc:block bg-surface border border-border rounded px-2 py-1 text-[10px] text-text-muted whitespace-nowrap shadow-lg pointer-events-auto">
-                          Powered by <span onClick={(e) => { e.preventDefault(); e.stopPropagation(); window.open('https://openclaw.ai/', '_blank'); }} className="text-accent hover:underline cursor-pointer">OpenClaw</span>
-                        </span>
-                      </span>
-                    );
-                  }
-                  const Mark = NAV_MARKS[key];
-                  return expanded ? (
-                    <span className="flex items-center gap-2.5 text-sm font-medium animate-slide-in">
-                      {Mark && <Mark className="shrink-0 opacity-70" />}
-                      {label}
-                    </span>
-                  ) : (
-                    Mark ? <Mark className="shrink-0" /> : <span className="font-mono text-[11px] font-medium tracking-tight">{abbr}</span>
+              <div className="flex flex-col gap-0.5">
+                {group.items.map(({ key, href, label, abbr, hidden }, index) => {
+                  const isActive = pathname === href || pathname.startsWith(href + '/');
+                  return (
+                    <NavItem
+                      key={key}
+                      itemKey={key}
+                      href={href}
+                      label={label}
+                      abbr={abbr}
+                      hidden={hidden}
+                      isActive={isActive}
+                      showExpanded={showExpanded}
+                      isConfigMode={false}
+                      mounted={mounted}
+                      index={index}
+                      dragKey={dragKey}
+                      dragOverKey={dragOverKey}
+                      setDragKey={setDragKey}
+                      setDragOverKey={setDragOverKey}
+                      config={config}
+                      setNavOrder={setNavOrder}
+                      togglePageVisibility={togglePageVisibility}
+                    />
                   );
-                })()}
-              </Link>
-
-              {/* Config mode: visibility toggle */}
-              {isConfigMode && expanded && (
-                <button
-                  onClick={() => togglePageVisibility(key, hidden)}
-                  className={cn(
-                    'flex h-6 w-6 shrink-0 items-center justify-center rounded transition-colors mr-1',
-                    hidden
-                      ? 'text-text-muted hover:text-text'
-                      : 'text-text hover:text-text-muted',
-                  )}
-                  title={hidden ? `Show ${label}` : `Hide ${label}`}
-                >
-                  {hidden ? (
-                    // Eye-off icon (simplified SVG)
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-                      <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-                      <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
-                      <line x1="1" y1="1" x2="23" y2="23" />
-                    </svg>
-                  ) : (
-                    // Eye icon (simplified SVG)
-                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                      <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                      <circle cx="12" cy="12" r="3" />
-                    </svg>
-                  )}
-                </button>
-              )}
-
+                })}
+              </div>
             </div>
-          );
-        })}
+          ))
+        )}
       </div>
 
       {/* Bottom */}
-      <div className="shrink-0 border-t border-border px-2 py-3">
+      <div className="shrink-0 border-t border-border/40 px-2.5 py-3">
         {/* Search trigger */}
         <div
           className={cn(
             'group relative flex h-9 items-center transition-all duration-150 w-full',
-            expanded ? 'px-3 gap-3 rounded-lg' : 'justify-center w-10 mx-auto rounded-md',
+            showExpanded ? 'px-2.5 gap-3 rounded-lg' : 'justify-center w-10 mx-auto rounded-lg',
           )}
         >
-          {expanded ? (
+          {showExpanded ? (
             <SearchTrigger variant="expanded" />
           ) : (
             <SearchTrigger variant="icon" />
           )}
         </div>
 
-        {expanded && <GatewayStatusIndicator />}
-
-        {/* Profile + menu (settings, configure, logout) */}
-        <ProfileBadge expanded={expanded} toggleConfigMode={toggleConfigMode} isConfigMode={isConfigMode} />
-
-        {/* Toggle arrow at the very bottom */}
-        {!expanded && (
-          <button
-            onClick={toggle}
-            className="flex h-9 w-10 mx-auto items-center justify-center text-text-muted hover:text-text transition-colors font-mono text-xs mt-1"
-            title="Expand sidebar"
-          >
-            &rarr;
-          </button>
-        )}
+        {/* Profile + menu */}
+        <ProfileBadge expanded={showExpanded} toggleConfigMode={toggleConfigMode} isConfigMode={isConfigMode} />
       </div>
     </nav>
   );
 }
+
+// ── Nav Item ──────────────────────────────────────────────
+
+interface NavItemProps {
+  itemKey: string;
+  href: string;
+  label: string;
+  abbr: string;
+  hidden: boolean;
+  isActive: boolean;
+  showExpanded: boolean;
+  isConfigMode: boolean;
+  mounted: boolean;
+  index: number;
+  dragKey: string | null;
+  dragOverKey: string | null;
+  setDragKey: (k: string | null) => void;
+  setDragOverKey: (k: string | null) => void;
+  config: { navOrder: string[] };
+  setNavOrder: (order: string[]) => void;
+  togglePageVisibility: (page: string, visible: boolean) => void;
+}
+
+function NavItem({
+  itemKey, href, label, abbr, hidden, isActive, showExpanded, isConfigMode,
+  mounted, index, dragKey, dragOverKey, setDragKey, setDragOverKey, config,
+  setNavOrder, togglePageVisibility,
+}: NavItemProps) {
+  return (
+    <div
+      className={cn(
+        'relative flex items-center',
+        isConfigMode && dragOverKey === itemKey && 'border-t-2 border-text',
+      )}
+      draggable={isConfigMode}
+      onDragStart={(e) => {
+        setDragKey(itemKey);
+        e.dataTransfer.effectAllowed = 'move';
+      }}
+      onDragOver={(e) => {
+        e.preventDefault();
+        e.dataTransfer.dropEffect = 'move';
+        setDragOverKey(itemKey);
+      }}
+      onDragLeave={() => setDragOverKey(null)}
+      onDrop={(e) => {
+        e.preventDefault();
+        setDragOverKey(null);
+        if (!dragKey || dragKey === itemKey) return;
+        const order = [...config.navOrder];
+        const fromIdx = order.indexOf(dragKey);
+        const toIdx = order.indexOf(itemKey);
+        if (fromIdx === -1 || toIdx === -1) return;
+        order.splice(fromIdx, 1);
+        order.splice(toIdx, 0, dragKey);
+        setNavOrder(order);
+        setDragKey(null);
+      }}
+      onDragEnd={() => { setDragKey(null); setDragOverKey(null); }}
+    >
+      {/* Drag grip in config mode */}
+      {isConfigMode && showExpanded && (
+        <span className="flex items-center justify-center w-5 shrink-0 cursor-grab text-text-muted/40 hover:text-text-muted">
+          <svg width="10" height="10" viewBox="0 0 10 10" fill="currentColor">
+            <circle cx="3" cy="2" r="1" /><circle cx="7" cy="2" r="1" />
+            <circle cx="3" cy="5" r="1" /><circle cx="7" cy="5" r="1" />
+            <circle cx="3" cy="8" r="1" /><circle cx="7" cy="8" r="1" />
+          </svg>
+        </span>
+      )}
+      <Link
+        href={href}
+        title={showExpanded ? undefined : label}
+        className={cn(
+          'group relative flex h-8 items-center transition-all duration-150 flex-1',
+          showExpanded
+            ? (isConfigMode ? 'px-1 gap-2.5 rounded-lg' : 'px-2.5 gap-2.5 rounded-lg')
+            : 'justify-center w-10 mx-auto rounded-lg',
+          hidden && 'opacity-40',
+          isActive
+            ? 'bg-surface-hover text-text'
+            : 'text-text-muted hover:bg-surface-hover hover:text-text',
+          isConfigMode && dragKey === itemKey && 'opacity-30',
+        )}
+        onClick={isConfigMode ? (e) => e.preventDefault() : undefined}
+      >
+        {(() => {
+          if (itemKey === 'life-coach') {
+            return showExpanded ? (
+              <span className="flex items-center gap-2.5 text-[13px] font-medium">
+                <img src="/openclaw-icon.png" alt="Life Coach" className="shrink-0 size-4 rounded-sm" />
+                {label}
+              </span>
+            ) : (
+              <img src="/openclaw-icon.png" alt="Life Coach" className="shrink-0 size-4 rounded-sm" />
+            );
+          }
+          const Mark = NAV_MARKS[itemKey];
+          return showExpanded ? (
+            <span className="flex items-center gap-2.5 text-[13px] font-medium">
+              {Mark && <Mark className="shrink-0 opacity-60" />}
+              {label}
+            </span>
+          ) : (
+            Mark ? <Mark className="shrink-0" /> : <span className="font-mono text-[11px] font-medium tracking-tight">{abbr}</span>
+          );
+        })()}
+      </Link>
+
+      {/* Config mode: visibility toggle */}
+      {isConfigMode && showExpanded && (
+        <button
+          onClick={() => togglePageVisibility(itemKey, hidden)}
+          className={cn(
+            'flex h-6 w-6 shrink-0 items-center justify-center rounded-md transition-colors mr-1',
+            hidden
+              ? 'text-text-muted hover:text-text'
+              : 'text-text hover:text-text-muted',
+          )}
+          title={hidden ? `Show ${label}` : `Hide ${label}`}
+        >
+          {hidden ? (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+              <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+              <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+              <line x1="1" y1="1" x2="23" y2="23" />
+            </svg>
+          ) : (
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+              <circle cx="12" cy="12" r="3" />
+            </svg>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// ── Profile Badge ─────────────────────────────────────────
 
 const PLAN_LABELS: Record<string, string> = {
   dashboard: 'Home',
@@ -335,7 +451,7 @@ function ProfileBadge({ expanded, toggleConfigMode, isConfigMode }: { expanded: 
         title={expanded ? undefined : `${user.name ?? user.email} — ${planLabel}`}
         className={cn(
           'flex items-center transition-all duration-150 w-full',
-          expanded ? 'gap-2.5 px-3 py-2 rounded-lg hover:bg-surface-hover' : 'justify-center w-10 mx-auto py-2',
+          expanded ? 'gap-2.5 px-2.5 py-2 rounded-lg hover:bg-surface-hover' : 'justify-center w-10 mx-auto py-2',
         )}
       >
         {profileImage ? (
@@ -355,7 +471,7 @@ function ProfileBadge({ expanded, toggleConfigMode, isConfigMode }: { expanded: 
 
       {menuOpen && (
         <div className={cn(
-          'absolute z-50 bg-surface border border-border rounded-lg shadow-lg py-1 animate-scale-in',
+          'absolute z-50 bg-surface border border-border rounded-xl shadow-lg py-1 animate-scale-in',
           expanded ? 'bottom-full left-0 right-0 mb-1' : 'bottom-full left-0 mb-1 w-48',
         )}>
           {/* Balance display */}
@@ -363,7 +479,7 @@ function ProfileBadge({ expanded, toggleConfigMode, isConfigMode }: { expanded: 
             <>
               <div className="px-3 py-2.5">
                 <p className="text-[10px] uppercase tracking-widest text-text-muted mb-0.5">Balance</p>
-                <p className="text-sm font-bold text-text font-mono tabular-nums">
+                <p className="text-sm font-bold text-text tabular-nums">
                   EUR {(balance / 100).toFixed(2)}
                 </p>
               </div>
@@ -375,7 +491,7 @@ function ProfileBadge({ expanded, toggleConfigMode, isConfigMode }: { expanded: 
           <div className="relative">
             <button
               onClick={() => setTopUpOpen(!topUpOpen)}
-              className="flex items-center justify-between gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-text hover:bg-surface-hover transition-colors w-full text-left"
+              className="flex items-center justify-between gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-text hover:bg-surface-hover transition-colors w-full text-left rounded-lg mx-0"
             >
               <span className="flex items-center gap-2.5">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
@@ -405,9 +521,9 @@ function ProfileBadge({ expanded, toggleConfigMode, isConfigMode }: { expanded: 
                         setCheckingOut(null);
                       }
                     }}
-                    className="flex items-center justify-between w-full px-2.5 py-1.5 text-xs text-text-muted hover:text-text hover:bg-surface-hover rounded transition-colors disabled:opacity-50"
+                    className="flex items-center justify-between w-full px-2.5 py-1.5 text-xs text-text-muted hover:text-text hover:bg-surface-hover rounded-lg transition-colors disabled:opacity-50"
                   >
-                    <span className="font-mono">{tier.label}</span>
+                    <span className="tabular-nums">{tier.label}</span>
                     {checkingOut === tier.priceId && (
                       <span className="text-[10px] text-text-muted animate-pulse">...</span>
                     )}
@@ -422,7 +538,7 @@ function ProfileBadge({ expanded, toggleConfigMode, isConfigMode }: { expanded: 
           <Link
             href="/settings"
             onClick={() => setMenuOpen(false)}
-            className="flex items-center gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            className="flex items-center gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-text hover:bg-surface-hover transition-colors rounded-lg mx-1"
           >
             <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <line x1="3" y1="13" x2="13" y2="3" /><circle cx="8" cy="8" r="2.5" />
@@ -431,18 +547,20 @@ function ProfileBadge({ expanded, toggleConfigMode, isConfigMode }: { expanded: 
           </Link>
           <button
             onClick={() => { setMenuOpen(false); toggleConfigMode(); }}
-            className="flex items-center gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-text hover:bg-surface-hover transition-colors w-full text-left"
+            className="flex items-center gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-text hover:bg-surface-hover transition-colors w-full text-left rounded-lg mx-1"
+            style={{ width: 'calc(100% - 0.5rem)' }}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
-              <rect x="3" y="3" width="7" height="7" /><rect x="14" y="3" width="7" height="7" />
-              <rect x="3" y="14" width="7" height="7" /><rect x="14" y="14" width="7" height="7" />
+              <rect x="3" y="3" width="7" height="7" rx="2" /><rect x="14" y="3" width="7" height="7" rx="2" />
+              <rect x="3" y="14" width="7" height="7" rx="2" /><rect x="14" y="14" width="7" height="7" rx="2" />
             </svg>
             {isConfigMode ? 'Done configuring' : 'Configure layout'}
           </button>
           <div className="my-1 border-t border-border/40" />
           <button
             onClick={() => { setMenuOpen(false); void signOut(); }}
-            className="flex items-center gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-danger hover:bg-surface-hover transition-colors w-full text-left"
+            className="flex items-center gap-2.5 px-3 py-2 text-xs text-text-muted hover:text-danger hover:bg-surface-hover transition-colors w-full text-left rounded-lg mx-1"
+            style={{ width: 'calc(100% - 0.5rem)' }}
           >
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
               <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />

--- a/web/src/components/page-shell.tsx
+++ b/web/src/components/page-shell.tsx
@@ -28,10 +28,11 @@ export function PageShell({ page, title, subtitle, children }: PageShellProps) {
 
       {/* Sections grid */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {preset.sections.map((section) => (
+        {preset.sections.map((section, index) => (
           <div
             key={section.id}
-            className={section.span === 'full' ? 'lg:col-span-2' : ''}
+            className={`animate-fade-in ${section.span === 'full' ? 'lg:col-span-2' : ''}`}
+            style={{ animationDelay: `${index * 50}ms` }}
           >
             <SectionRenderer section={section} />
           </div>

--- a/web/src/components/project-detail-modal.tsx
+++ b/web/src/components/project-detail-modal.tsx
@@ -1,0 +1,483 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/lib/convex-api';
+import type { Id } from '@/lib/convex-api';
+import { cn } from '@/lib/utils';
+
+type ProjectStatus = 'active' | 'completed' | 'archived';
+
+const STATUS_OPTIONS: { value: ProjectStatus; label: string; color: string; dot: string }[] = [
+  { value: 'active', label: 'Active', color: 'text-success', dot: 'bg-success' },
+  { value: 'completed', label: 'Completed', color: 'text-accent', dot: 'bg-accent' },
+  { value: 'archived', label: 'Archived', color: 'text-text-muted', dot: 'bg-text-muted' },
+];
+
+export function ProjectDetailModal({
+  projectId,
+  onClose,
+}: {
+  projectId: Id<'projects'>;
+  onClose: () => void;
+}) {
+  const projectDetail = useQuery(api.projects.get, { id: projectId });
+  const updateProject = useMutation(api.projects.update);
+  const removeProject = useMutation(api.projects.remove);
+  const createTask = useMutation(api.tasks.create);
+  const completeTask = useMutation(api.tasks.complete);
+
+  const [titleValue, setTitleValue] = useState('');
+  const [descriptionValue, setDescriptionValue] = useState('');
+  const [statusOpen, setStatusOpen] = useState(false);
+  const [confirmDelete, setConfirmDelete] = useState(false);
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [addingTask, setAddingTask] = useState(false);
+  const [newTaskTitle, setNewTaskTitle] = useState('');
+
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const descriptionRef = useRef<HTMLTextAreaElement>(null);
+  const statusRef = useRef<HTMLDivElement>(null);
+  const newTaskInputRef = useRef<HTMLInputElement>(null);
+  const initializedRef = useRef(false);
+
+  // Initialize local state from project data
+  useEffect(() => {
+    if (projectDetail && !initializedRef.current) {
+      setTitleValue(projectDetail.title);
+      setDescriptionValue(projectDetail.description ?? '');
+      initializedRef.current = true;
+    }
+  }, [projectDetail]);
+
+  // Reset initialized flag when projectId changes
+  useEffect(() => {
+    initializedRef.current = false;
+  }, [projectId]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Prevent body scroll
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }, []);
+
+  // Close status dropdown on outside click
+  useEffect(() => {
+    if (!statusOpen) return;
+    function handleClick(e: MouseEvent) {
+      if (statusRef.current && !statusRef.current.contains(e.target as Node)) {
+        setStatusOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, [statusOpen]);
+
+  // Auto-resize description textarea
+  const autoResize = useCallback(() => {
+    if (descriptionRef.current) {
+      descriptionRef.current.style.height = 'auto';
+      descriptionRef.current.style.height = `${descriptionRef.current.scrollHeight}px`;
+    }
+  }, []);
+
+  useEffect(() => { autoResize(); }, [descriptionValue, autoResize]);
+
+  // Focus new task input when addingTask becomes true
+  useEffect(() => {
+    if (addingTask) {
+      setTimeout(() => newTaskInputRef.current?.focus(), 0);
+    }
+  }, [addingTask]);
+
+  const handleTitleBlur = useCallback(async () => {
+    setEditingTitle(false);
+    if (titleValue.trim() && projectDetail && titleValue.trim() !== projectDetail.title) {
+      try {
+        await updateProject({ id: projectId, title: titleValue.trim() });
+      } catch (err) {
+        console.error('Failed to update project title:', err);
+      }
+    }
+  }, [titleValue, projectDetail, projectId, updateProject]);
+
+  const handleDescriptionBlur = useCallback(async () => {
+    if (projectDetail && descriptionValue !== (projectDetail.description ?? '')) {
+      try {
+        await updateProject({ id: projectId, description: descriptionValue });
+      } catch (err) {
+        console.error('Failed to update project description:', err);
+      }
+    }
+  }, [descriptionValue, projectDetail, projectId, updateProject]);
+
+  const handleStatusSelect = useCallback(async (status: ProjectStatus) => {
+    setStatusOpen(false);
+    try {
+      await updateProject({ id: projectId, status });
+    } catch (err) {
+      console.error('Failed to update project status:', err);
+    }
+  }, [projectId, updateProject]);
+
+  const handleDelete = useCallback(async () => {
+    try {
+      await removeProject({ id: projectId });
+      onClose();
+    } catch (err) {
+      console.error('Failed to delete project:', err);
+    }
+  }, [removeProject, projectId, onClose]);
+
+  const handleCompleteTask = useCallback(async (taskId: Id<'tasks'>) => {
+    try {
+      await completeTask({ id: taskId });
+    } catch (err) {
+      console.error('Failed to complete task:', err);
+    }
+  }, [completeTask]);
+
+  const handleAddTask = useCallback(async () => {
+    if (!newTaskTitle.trim()) return;
+    try {
+      await createTask({ title: newTaskTitle.trim(), projectId });
+      setNewTaskTitle('');
+      setAddingTask(false);
+    } catch (err) {
+      console.error('Failed to add task:', err);
+    }
+  }, [createTask, newTaskTitle, projectId]);
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  }, [onClose]);
+
+  if (!projectDetail) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+        onClick={handleBackdropClick}
+      >
+        <div className="rounded-2xl bg-surface border border-border shadow-2xl max-w-3xl w-full mx-4 p-8">
+          <div className="flex items-center justify-center">
+            <div className="h-6 w-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const currentStatus = STATUS_OPTIONS.find((o) => o.value === projectDetail.status) ?? STATUS_OPTIONS[0];
+  const createdDate = new Date(projectDetail._creationTime).toLocaleDateString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  const tasks = projectDetail.tasks ?? [];
+  const todoTasks = tasks.filter((t) => t.status === 'todo');
+  const doneTasks = tasks.filter((t) => t.status === 'done');
+  const droppedTasks = tasks.filter((t) => t.status === 'dropped');
+  const totalTasks = tasks.length;
+  const completedCount = doneTasks.length;
+  const progressPct = totalTasks > 0 ? Math.round((completedCount / totalTasks) * 100) : 0;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="rounded-2xl bg-surface border border-border shadow-2xl max-w-3xl w-full mx-4 flex flex-col max-h-[80vh] overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-end px-4 py-3 border-b border-border/50">
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left panel -- title, description, tasks */}
+          <div className="flex-[3] p-6 overflow-y-auto space-y-5">
+            {/* Title */}
+            <div>
+              {editingTitle ? (
+                <input
+                  ref={titleInputRef}
+                  type="text"
+                  value={titleValue}
+                  onChange={(e) => setTitleValue(e.target.value)}
+                  onBlur={handleTitleBlur}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      (e.target as HTMLInputElement).blur();
+                    }
+                  }}
+                  className="w-full bg-transparent text-lg font-semibold text-text focus:outline-none"
+                  autoFocus
+                />
+              ) : (
+                <h2
+                  className="text-lg font-semibold text-text cursor-text hover:text-accent/80 transition-colors"
+                  onClick={() => {
+                    setEditingTitle(true);
+                    setTimeout(() => titleInputRef.current?.focus(), 0);
+                  }}
+                >
+                  {titleValue || projectDetail.title}
+                </h2>
+              )}
+            </div>
+
+            {/* Description */}
+            <textarea
+              ref={descriptionRef}
+              value={descriptionValue}
+              onChange={(e) => {
+                setDescriptionValue(e.target.value);
+                autoResize();
+              }}
+              onBlur={handleDescriptionBlur}
+              placeholder="Add description..."
+              rows={3}
+              className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none resize-none leading-relaxed"
+            />
+
+            {/* Linked Tasks */}
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">
+                  Linked Tasks ({totalTasks})
+                </span>
+                <button
+                  type="button"
+                  onClick={() => setAddingTask(true)}
+                  className="text-[11px] font-medium text-accent hover:text-accent-hover transition-colors"
+                >
+                  + Add task
+                </button>
+              </div>
+
+              {/* Add task inline */}
+              {addingTask && (
+                <div className="flex items-center gap-2">
+                  <input
+                    ref={newTaskInputRef}
+                    type="text"
+                    value={newTaskTitle}
+                    onChange={(e) => setNewTaskTitle(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        handleAddTask();
+                      }
+                      if (e.key === 'Escape') {
+                        setAddingTask(false);
+                        setNewTaskTitle('');
+                      }
+                    }}
+                    placeholder="Task title..."
+                    className="flex-1 bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none border-b border-border focus:border-accent transition-colors py-1"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleAddTask}
+                    disabled={!newTaskTitle.trim()}
+                    className="text-xs font-medium text-accent hover:text-accent-hover disabled:opacity-40 transition-colors"
+                  >
+                    Add
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => { setAddingTask(false); setNewTaskTitle(''); }}
+                    className="text-xs text-text-muted hover:text-text transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+
+              {tasks.length === 0 && !addingTask ? (
+                <p className="text-xs text-text-muted italic">No linked tasks</p>
+              ) : (
+                <div className="space-y-0.5">
+                  {/* Todo tasks first */}
+                  {todoTasks.map((task) => (
+                    <div
+                      key={task._id}
+                      className="flex items-center gap-2 text-sm py-1.5 group/task"
+                    >
+                      <button
+                        type="button"
+                        onClick={() => handleCompleteTask(task._id)}
+                        className="h-4 w-4 rounded border border-border hover:border-accent shrink-0 transition-colors flex items-center justify-center group-hover/task:border-accent/60"
+                        aria-label="Complete task"
+                      />
+                      <span className="flex-1 min-w-0 truncate text-text">
+                        {task.title}
+                      </span>
+                      {task.dueDate && (
+                        <span className="text-xs text-text-muted ml-auto font-mono shrink-0">
+                          {task.dueDate}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                  {/* Done tasks */}
+                  {doneTasks.map((task) => (
+                    <div
+                      key={task._id}
+                      className="flex items-center gap-2 text-sm py-1.5"
+                    >
+                      <div className="h-4 w-4 rounded border border-success/40 bg-success/20 shrink-0 flex items-center justify-center">
+                        <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="text-success">
+                          <polyline points="20 6 9 17 4 12" />
+                        </svg>
+                      </div>
+                      <span className="flex-1 min-w-0 truncate text-text-muted line-through">
+                        {task.title}
+                      </span>
+                      {task.dueDate && (
+                        <span className="text-xs text-text-muted/60 ml-auto font-mono shrink-0">
+                          {task.dueDate}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+                  {/* Dropped tasks */}
+                  {droppedTasks.map((task) => (
+                    <div
+                      key={task._id}
+                      className="flex items-center gap-2 text-sm py-1.5"
+                    >
+                      <div className="h-4 w-4 rounded border border-text-muted/30 bg-text-muted/10 shrink-0" />
+                      <span className="flex-1 min-w-0 truncate text-text-muted line-through">
+                        {task.title}
+                      </span>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Right panel -- metadata sidebar */}
+          <div className="flex-[2] border-l border-border bg-bg-subtle p-5 overflow-y-auto space-y-4">
+            {/* Status */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Status</span>
+              <div className="relative" ref={statusRef}>
+                <button
+                  type="button"
+                  onClick={() => setStatusOpen((prev) => !prev)}
+                  className="flex items-center gap-2 w-full text-left text-sm rounded-lg px-2.5 py-2 hover:bg-surface-hover transition-colors"
+                >
+                  <span className={cn('h-2 w-2 rounded-full shrink-0', currentStatus.dot)} />
+                  <span className={currentStatus.color}>{currentStatus.label}</span>
+                </button>
+                {statusOpen && (
+                  <div className="absolute z-50 top-full left-0 mt-1 w-full border border-border bg-surface rounded-lg shadow-xl overflow-hidden">
+                    {STATUS_OPTIONS.map((opt) => (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        onClick={() => handleStatusSelect(opt.value)}
+                        className={cn(
+                          'w-full text-left px-3 py-2 text-xs transition-colors hover:bg-surface-hover flex items-center gap-2',
+                          projectDetail.status === opt.value && 'bg-accent/10 font-medium',
+                        )}
+                      >
+                        <span className={cn('h-2 w-2 rounded-full shrink-0', opt.dot)} />
+                        <span className={opt.color}>{opt.label}</span>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {/* Task Progress */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Task Progress</span>
+              <div className="px-2.5 py-2 space-y-2">
+                <div className="flex items-center justify-between text-sm">
+                  <span className="text-text">{completedCount}/{totalTasks} tasks done</span>
+                  <span className="text-xs text-text-muted">{progressPct}%</span>
+                </div>
+                <div className="w-full h-1.5 bg-border rounded-full overflow-hidden">
+                  <div
+                    className="h-full bg-accent rounded-full transition-all duration-300"
+                    style={{ width: `${progressPct}%` }}
+                  />
+                </div>
+              </div>
+            </div>
+
+            {/* Created */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Created</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm text-text-muted rounded-lg">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-50 shrink-0">
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+                <span>{createdDate}</span>
+              </div>
+            </div>
+
+            {/* Delete */}
+            <div className="pt-2 border-t border-border/40">
+              {!confirmDelete ? (
+                <button
+                  type="button"
+                  onClick={() => setConfirmDelete(true)}
+                  className="w-full text-center text-xs text-text-muted hover:text-danger py-2 rounded-lg hover:bg-surface-hover transition-colors"
+                >
+                  Delete project
+                </button>
+              ) : (
+                <div className="flex gap-2">
+                  <button
+                    type="button"
+                    onClick={handleDelete}
+                    className="flex-1 text-xs font-medium text-danger bg-danger/10 hover:bg-danger/20 py-1.5 rounded-lg transition-colors"
+                  >
+                    Confirm Delete
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setConfirmDelete(false)}
+                    className="text-xs text-text-muted hover:text-text py-1.5 px-3 rounded-lg hover:bg-surface-hover transition-colors"
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/quick-capture.tsx
+++ b/web/src/components/quick-capture.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
-import { cn } from '@/lib/utils';
+import { useSlashCommands, SlashCommandMenu, type SlashCommand } from '@/components/slash-command-menu';
 
-type CaptureType = 'task' | 'idea' | 'thought' | 'win';
+type CaptureType = 'task' | 'idea' | 'thought' | 'win' | 'reminder';
 
 const captureTypes: {
   type: CaptureType;
@@ -15,17 +15,102 @@ const captureTypes: {
   { type: 'idea', label: 'Idea' },
   { type: 'thought', label: 'Thought' },
   { type: 'win', label: 'Win' },
+  { type: 'reminder', label: 'Reminder' },
 ];
 
 export function QuickCapture() {
   const [value, setValue] = useState('');
   const [type, setType] = useState<CaptureType>('task');
   const [saving, setSaving] = useState(false);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
 
   const createTask = useMutation(api.tasks.create);
   const createIdea = useMutation(api.ideas.create);
   const createThought = useMutation(api.thoughts.create);
   const createWin = useMutation(api.wins.create);
+  const createReminder = useMutation(api.reminders.create);
+
+  const slashCommands: SlashCommand[] = useMemo(
+    () => [
+      {
+        id: 'task',
+        label: 'Task',
+        description: 'Create a new task',
+        icon: (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14" />
+            <polyline points="22 4 12 14.01 9 11.01" />
+          </svg>
+        ),
+        action: () => setType('task'),
+      },
+      {
+        id: 'idea',
+        label: 'Idea',
+        description: 'Capture an idea',
+        icon: (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="9" y1="18" x2="15" y2="18" />
+            <line x1="10" y1="22" x2="14" y2="22" />
+            <path d="M15.09 14c.18-.98.65-1.74 1.41-2.5A4.65 4.65 0 0 0 18 8 6 6 0 0 0 6 8c0 1 .23 2.23 1.5 3.5A4.61 4.61 0 0 1 8.91 14" />
+          </svg>
+        ),
+        action: () => setType('idea'),
+      },
+      {
+        id: 'thought',
+        label: 'Thought',
+        description: 'Record a thought',
+        icon: (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+          </svg>
+        ),
+        action: () => setType('thought'),
+      },
+      {
+        id: 'win',
+        label: 'Win',
+        description: 'Log a win',
+        icon: (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="8" r="7" />
+            <polyline points="8.21 13.89 7 23 12 20 17 23 15.79 13.88" />
+          </svg>
+        ),
+        action: () => setType('win'),
+      },
+      {
+        id: 'reminder',
+        label: 'Reminder',
+        description: 'Set a reminder',
+        icon: (
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+          </svg>
+        ),
+        action: () => setType('reminder'),
+      },
+    ],
+    []
+  );
+
+  const slash = useSlashCommands(slashCommands, (cleanedText) => {
+    setValue(cleanedText);
+  });
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
+        setDropdownOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   const submit = async () => {
     if (!value.trim() || saving) return;
@@ -44,6 +129,12 @@ export function QuickCapture() {
         case 'win':
           await createWin({ content: value.trim() });
           break;
+        case 'reminder':
+          await createReminder({
+            title: value.trim(),
+            scheduledAt: Date.now() + 60 * 60 * 1000, // default 1 hour from now
+          });
+          break;
       }
       setValue('');
     } finally {
@@ -51,38 +142,97 @@ export function QuickCapture() {
     }
   };
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = e.target.value;
+    setValue(newValue);
+    const cursorPosition = e.target.selectionStart ?? newValue.length;
+    slash.handleInputChange(newValue, cursorPosition);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    // Let slash commands handle first
+    if (slash.handleKeyDown(e)) return;
+    if (e.key === 'Enter') void submit();
+  };
+
+  const currentLabel = captureTypes.find((c) => c.type === type)?.label ?? 'Task';
+
   return (
-    <div className="border border-border flex items-center">
-      {/* Type selector pills */}
-      <div className="flex shrink-0 border-r border-border">
-        {captureTypes.map(({ type: t, label }) => (
-          <button
-            key={t}
-            onClick={() => setType(t)}
-            className={cn(
-              'px-4 py-3 text-xs font-medium uppercase tracking-wide transition-colors',
-              type === t
-                ? 'text-text border-b-2 border-text'
-                : 'text-text-muted hover:text-text',
-            )}
+    <div className="relative border border-border rounded-xl flex items-center overflow-visible">
+      {/* Type dropdown */}
+      <div className="relative shrink-0" ref={dropdownRef}>
+        <button
+          onClick={() => setDropdownOpen((o) => !o)}
+          className="flex items-center gap-1.5 px-4 py-3 text-xs font-medium uppercase tracking-wide text-text-muted transition-colors hover:text-text"
+        >
+          {currentLabel}
+          <svg
+            width="12"
+            height="12"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="opacity-50"
           >
-            {label}
-          </button>
-        ))}
+            <polyline points="6 9 12 15 18 9" />
+          </svg>
+        </button>
+        {dropdownOpen && (
+          <div className="absolute left-0 top-full z-50 mt-1 min-w-[120px] rounded-lg border border-border bg-surface shadow-lg">
+            {captureTypes.map(({ type: t, label }) => (
+              <button
+                key={t}
+                onClick={() => {
+                  setType(t);
+                  setDropdownOpen(false);
+                }}
+                className={`block w-full px-4 py-2 text-left text-xs font-medium uppercase tracking-wide transition-colors ${
+                  type === t
+                    ? 'text-text bg-surface-hover'
+                    : 'text-text-muted hover:text-text hover:bg-surface-hover'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
       </div>
+
+      {/* Divider */}
+      <div className="w-px h-6 bg-border shrink-0" />
+
       {/* Input */}
-      <input
-        value={value}
-        onChange={(e) => setValue(e.target.value)}
-        onKeyDown={(e) => e.key === 'Enter' && submit()}
-        placeholder={`Quick capture ${type}...`}
-        className="flex-1 bg-transparent text-sm text-text placeholder:text-text-muted/50 outline-none px-4 py-3"
-      />
+      <div className="flex-1 relative">
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          placeholder={`Quick capture ${type}... (type / for commands)`}
+          className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/50 outline-none px-4 py-3"
+        />
+
+        {/* Slash command menu */}
+        {slash.menuVisible && (
+          <div className="absolute left-2 bottom-full mb-2 z-50">
+            <SlashCommandMenu
+              commands={slash.filteredCommands}
+              selectedIndex={slash.selectedIndex}
+              onSelect={slash.selectCommand}
+            />
+          </div>
+        )}
+      </div>
+
       {/* Submit */}
       <button
         onClick={submit}
         disabled={!value.trim() || saving}
-        className="shrink-0 bg-white text-black px-5 py-3 text-xs font-medium uppercase tracking-wide transition-colors hover:bg-white/90 disabled:opacity-20 disabled:pointer-events-none"
+        className="shrink-0 bg-white text-black rounded-lg px-5 py-2 mr-1.5 text-xs font-medium uppercase tracking-wide transition-colors hover:bg-white/90 disabled:opacity-20 disabled:pointer-events-none"
       >
         Add
       </button>

--- a/web/src/components/search-modal.tsx
+++ b/web/src/components/search-modal.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useQuery } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { cn } from '@/lib/utils';
+import { useDashboardConfig } from '@/lib/dashboard-config';
 
 // ── Constants ─────────────────────────────────────────
 
@@ -33,6 +34,15 @@ interface FlatResult {
   title: string;
   subtitle: string;
   path: string;
+}
+
+interface Command {
+  id: string;
+  label: string;
+  category: 'create' | 'navigate' | 'action';
+  icon: React.ReactNode;
+  action: () => void;
+  keywords: string[];
 }
 
 // ── Helpers ───────────────────────────────────────────
@@ -146,6 +156,49 @@ function ClockIcon() {
   );
 }
 
+function PlusIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+      <line x1="12" y1="5" x2="12" y2="19" />
+      <line x1="5" y1="12" x2="19" y2="12" />
+    </svg>
+  );
+}
+
+function ArrowRightIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+      <line x1="5" y1="12" x2="19" y2="12" />
+      <polyline points="12 5 19 12 12 19" />
+    </svg>
+  );
+}
+
+function PlayIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+      <polygon points="5 3 19 12 5 21 5 3" />
+    </svg>
+  );
+}
+
+function SettingsIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="shrink-0">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" />
+    </svg>
+  );
+}
+
+const COMMAND_CATEGORY_LABELS: Record<string, string> = {
+  create: 'Quick Actions',
+  navigate: 'Navigate',
+  action: 'Actions',
+};
+
+const COMMAND_CATEGORY_ORDER = ['create', 'navigate', 'action'] as const;
+
 // ── Component ─────────────────────────────────────────
 
 export function SearchModal() {
@@ -156,6 +209,85 @@ export function SearchModal() {
   const inputRef = useRef<HTMLInputElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+  const { toggleConfigMode } = useDashboardConfig();
+
+  // ── Build commands list ─────────────────────────────
+  const commands: Command[] = useMemo(() => {
+    const close = () => setOpen(false);
+
+    const nav = (path: string) => () => {
+      close();
+      router.push(path);
+    };
+
+    return [
+      // Create actions
+      { id: 'new-task', label: 'New Task', category: 'create' as const, icon: <PlusIcon />, action: nav('/tasks'), keywords: ['create', 'add', 'task', 'todo'] },
+      { id: 'new-idea', label: 'New Idea', category: 'create' as const, icon: <PlusIcon />, action: nav('/ideas'), keywords: ['create', 'add', 'idea', 'capture'] },
+      { id: 'new-thought', label: 'New Thought', category: 'create' as const, icon: <PlusIcon />, action: nav('/thoughts'), keywords: ['create', 'add', 'thought', 'note'] },
+      { id: 'new-project', label: 'New Project', category: 'create' as const, icon: <PlusIcon />, action: nav('/projects'), keywords: ['create', 'add', 'project'] },
+      { id: 'new-goal', label: 'New Goal', category: 'create' as const, icon: <PlusIcon />, action: nav('/goals'), keywords: ['create', 'add', 'goal', 'objective'] },
+      { id: 'new-win', label: 'New Win', category: 'create' as const, icon: <PlusIcon />, action: nav('/journal'), keywords: ['create', 'add', 'win', 'celebrate'] },
+      { id: 'new-reminder', label: 'New Reminder', category: 'create' as const, icon: <PlusIcon />, action: nav('/today'), keywords: ['create', 'add', 'reminder', 'alert'] },
+
+      // Navigate actions
+      { id: 'go-today', label: 'Go to Today', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/today'), keywords: ['home', 'today', 'now'] },
+      { id: 'go-tasks', label: 'Go to Tasks', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/tasks'), keywords: ['tasks', 'todos'] },
+      { id: 'go-projects', label: 'Go to Projects', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/projects'), keywords: ['projects'] },
+      { id: 'go-compass', label: 'Go to Compass', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/goals'), keywords: ['goals', 'compass', 'objectives'] },
+      { id: 'go-journal', label: 'Go to Journal', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/journal'), keywords: ['journal', 'diary', 'log'] },
+      { id: 'go-ideas', label: 'Go to Ideas', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/ideas'), keywords: ['ideas', 'brainstorm'] },
+      { id: 'go-thoughts', label: 'Go to Thoughts', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/thoughts'), keywords: ['thoughts', 'notes'] },
+      { id: 'go-reviews', label: 'Go to Reviews', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/reviews'), keywords: ['reviews', 'reflect'] },
+      { id: 'go-resources', label: 'Go to Resources', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/resources'), keywords: ['resources', 'links', 'bookmarks'] },
+      { id: 'go-schedules', label: 'Go to Schedules', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/calendar'), keywords: ['calendar', 'schedules', 'plan'] },
+      { id: 'go-settings', label: 'Go to Settings', category: 'navigate' as const, icon: <ArrowRightIcon />, action: nav('/settings'), keywords: ['settings', 'preferences', 'config'] },
+
+      // Actions
+      { id: 'start-weekly-review', label: 'Start Weekly Review', category: 'action' as const, icon: <PlayIcon />, action: nav('/reviews'), keywords: ['weekly', 'review', 'start'] },
+      { id: 'start-daily-review', label: 'Start Daily Review', category: 'action' as const, icon: <PlayIcon />, action: nav('/reviews'), keywords: ['daily', 'review', 'start'] },
+      {
+        id: 'configure-layout',
+        label: 'Configure Layout',
+        category: 'action' as const,
+        icon: <SettingsIcon />,
+        action: () => {
+          close();
+          toggleConfigMode();
+        },
+        keywords: ['configure', 'layout', 'customize', 'theme', 'design'],
+      },
+    ];
+  }, [router, toggleConfigMode]);
+
+  // ── Filter commands by query ────────────────────────
+  const filteredCommands = useMemo(() => {
+    const raw = query.trim();
+    if (raw === '' || raw === '>') return commands;
+
+    const search = (raw.startsWith('>') ? raw.slice(1) : raw).trim().toLowerCase();
+    if (search === '') return commands;
+
+    return commands.filter(cmd => {
+      const haystack = [cmd.label, ...cmd.keywords].join(' ').toLowerCase();
+      return search.split(/\s+/).every(term => haystack.includes(term));
+    });
+  }, [query, commands]);
+
+  // ── Group filtered commands by category ─────────────
+  const commandGroups = useMemo(() => {
+    const groups: { category: string; label: string; items: Command[] }[] = [];
+    for (const cat of COMMAND_CATEGORY_ORDER) {
+      const items = filteredCommands.filter(c => c.category === cat);
+      if (items.length > 0) {
+        groups.push({ category: cat, label: COMMAND_CATEGORY_LABELS[cat] ?? cat, items });
+      }
+    }
+    return groups;
+  }, [filteredCommands]);
+
+  // ── Determine if we're in command-only mode ─────────
+  const isCommandMode = query.trim().startsWith('>');
 
   // ── Keyboard shortcut: Cmd+K / Ctrl+K ──────────────
   useEffect(() => {
@@ -195,14 +327,21 @@ export function SearchModal() {
     }
   }, [open]);
 
+  // ── Determine search query (strip > prefix) ────────
+  const effectiveSearchQuery = useMemo(() => {
+    const raw = debouncedQuery.trim();
+    if (raw.startsWith('>')) return '';
+    return raw;
+  }, [debouncedQuery]);
+
   // ── Query Convex ────────────────────────────────────
   const rawResults = useQuery(
     api.search.search,
-    debouncedQuery.trim().length > 0 ? { q: debouncedQuery.trim() } : 'skip'
+    effectiveSearchQuery.length > 0 ? { q: effectiveSearchQuery } : 'skip'
   );
 
   // ── Flatten results into ordered list ───────────────
-  const { sections, flatItems } = useMemo(() => {
+  const { sections, flatItems: searchFlatItems } = useMemo(() => {
     if (!rawResults || typeof rawResults !== 'object') {
       return { sections: [] as { key: string; label: string; items: FlatResult[] }[], flatItems: [] as FlatResult[] };
     }
@@ -223,19 +362,50 @@ export function SearchModal() {
     return { sections: secs, flatItems: flat };
   }, [rawResults]);
 
-  // ── Reset selected index when results change ────────
+  // ── Build unified selectable items list ─────────────
+  // Commands come first, then search results
+  const totalSelectableCount = filteredCommands.length + searchFlatItems.length;
+
+  // Determine which commands and results to show
+  const isSearching = effectiveSearchQuery.length > 0;
+  const isLoading = isSearching && rawResults === undefined;
+  const hasSearchResults = sections.length > 0;
+  const noSearchResults = isSearching && !isLoading && !hasSearchResults;
+  const showCommands = filteredCommands.length > 0;
+  const showRecent = !isSearching && !isCommandMode && !query.trim();
+
+  // ── Reset selected index when items change ──────────
   useEffect(() => {
     setSelectedIndex(0);
-  }, [flatItems]);
+  }, [filteredCommands.length, searchFlatItems.length, query]);
+
+  // ── Execute action for current selection ────────────
+  const executeSelected = useCallback(() => {
+    if (selectedIndex < filteredCommands.length) {
+      // Selected item is a command
+      filteredCommands[selectedIndex].action();
+    } else {
+      // Selected item is a search result
+      const resultIndex = selectedIndex - filteredCommands.length;
+      const item = searchFlatItems[resultIndex];
+      if (item) {
+        if (effectiveSearchQuery) {
+          saveRecentSearch(effectiveSearchQuery);
+        }
+        setOpen(false);
+        router.push(item.path);
+      }
+    }
+  }, [selectedIndex, filteredCommands, searchFlatItems, effectiveSearchQuery, router]);
 
   // ── Navigate to a result ────────────────────────────
   const navigateTo = useCallback((path: string) => {
-    if (debouncedQuery.trim()) {
-      saveRecentSearch(debouncedQuery.trim());
+    if (effectiveSearchQuery) {
+      saveRecentSearch(effectiveSearchQuery);
     }
     setOpen(false);
     router.push(path);
-  }, [router, debouncedQuery]);
+  }, [router, effectiveSearchQuery]);
 
   // ── Keyboard navigation ─────────────────────────────
   useEffect(() => {
@@ -251,8 +421,9 @@ export function SearchModal() {
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setSelectedIndex(prev => {
+          const max = totalSelectableCount;
           const next = prev + 1;
-          return next >= flatItems.length ? 0 : next;
+          return next >= max ? 0 : next;
         });
         return;
       }
@@ -260,25 +431,23 @@ export function SearchModal() {
       if (e.key === 'ArrowUp') {
         e.preventDefault();
         setSelectedIndex(prev => {
+          const max = totalSelectableCount;
           const next = prev - 1;
-          return next < 0 ? Math.max(flatItems.length - 1, 0) : next;
+          return next < 0 ? Math.max(max - 1, 0) : next;
         });
         return;
       }
 
       if (e.key === 'Enter') {
         e.preventDefault();
-        const item = flatItems[selectedIndex];
-        if (item) {
-          navigateTo(item.path);
-        }
+        executeSelected();
         return;
       }
     };
 
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [open, flatItems, selectedIndex, navigateTo]);
+  }, [open, totalSelectableCount, executeSelected]);
 
   // ── Scroll selected item into view ──────────────────
   useEffect(() => {
@@ -297,13 +466,8 @@ export function SearchModal() {
 
   if (!open) return null;
 
-  const isSearching = debouncedQuery.trim().length > 0;
-  const isLoading = isSearching && rawResults === undefined;
-  const hasResults = sections.length > 0;
-  const noResults = isSearching && !isLoading && !hasResults;
-  const showRecent = !isSearching && recentSearches.length > 0;
-
-  let flatIndex = -1;
+  // Track the global flat index for keyboard navigation across commands + results
+  let globalIndex = -1;
 
   return (
     <div
@@ -312,7 +476,7 @@ export function SearchModal() {
         if (e.target === e.currentTarget) setOpen(false);
       }}
     >
-      <div className="w-full max-w-2xl mx-4 mt-[15vh] h-fit max-h-[60vh] flex flex-col border border-border bg-bg shadow-2xl">
+      <div className="w-full max-w-2xl mx-4 mt-[15vh] h-fit max-h-[60vh] flex flex-col rounded-xl border border-border bg-bg shadow-2xl overflow-hidden">
         {/* ── Search input row ─────────────────────────── */}
         <div className="flex items-center gap-3 border-b border-border px-4 py-3">
           <SearchIcon className="shrink-0 text-text-muted" />
@@ -321,7 +485,7 @@ export function SearchModal() {
             type="text"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search LifeOS..."
+            placeholder="Search or type > for commands..."
             className="flex-1 bg-transparent text-lg text-text placeholder:text-text-muted/50 focus:outline-none"
           />
           <kbd className="hidden sm:inline-flex h-5 items-center gap-0.5 rounded border border-border bg-surface px-1.5 text-[10px] font-mono text-text-muted">
@@ -331,6 +495,54 @@ export function SearchModal() {
 
         {/* ── Results area ─────────────────────────────── */}
         <div ref={listRef} className="flex-1 overflow-y-auto">
+          {/* Commands section */}
+          {showCommands && (
+            <div className="py-2">
+              {commandGroups.map(({ category, label, items }) => (
+                <div key={category} className="mb-1">
+                  <p className="px-4 pt-3 pb-1 text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                    {label}
+                  </p>
+                  {items.map((cmd) => {
+                    globalIndex++;
+                    const idx = globalIndex;
+                    const isSelected = idx === selectedIndex;
+
+                    return (
+                      <button
+                        key={cmd.id}
+                        data-result-index={idx}
+                        className={cn(
+                          'flex w-full items-center gap-3 px-4 py-2 text-left transition-colors rounded-lg mx-0',
+                          isSelected
+                            ? 'bg-surface text-text'
+                            : 'text-text-muted hover:bg-surface/50 hover:text-text',
+                        )}
+                        onClick={() => cmd.action()}
+                        onMouseEnter={() => setSelectedIndex(idx)}
+                      >
+                        <span className={cn(
+                          'flex items-center justify-center w-7 h-7 rounded-lg border',
+                          isSelected ? 'border-accent/30 bg-accent/10 text-accent' : 'border-border bg-surface text-text-muted',
+                        )}>
+                          {cmd.icon}
+                        </span>
+                        <span className="flex-1 min-w-0 truncate text-sm">
+                          {cmd.label}
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Separator between commands and search results */}
+          {showCommands && hasSearchResults && (
+            <div className="mx-4 border-t border-border" />
+          )}
+
           {/* Loading state */}
           {isLoading && (
             <div className="px-4 py-8 text-center">
@@ -339,16 +551,16 @@ export function SearchModal() {
           )}
 
           {/* No results */}
-          {noResults && (
+          {noSearchResults && !showCommands && (
             <div className="px-4 py-8 text-center">
               <p className="text-sm text-text-muted">
-                No results for &ldquo;{debouncedQuery.trim()}&rdquo;
+                No results for &ldquo;{effectiveSearchQuery}&rdquo;
               </p>
             </div>
           )}
 
-          {/* Recent searches (shown when input is empty) */}
-          {showRecent && (
+          {/* Recent searches (shown when input is empty and no command mode) */}
+          {showRecent && recentSearches.length > 0 && (
             <div className="px-2 py-3">
               <p className="px-2 pb-2 text-[10px] font-bold uppercase tracking-widest text-text-muted">
                 Recent searches
@@ -356,7 +568,7 @@ export function SearchModal() {
               {recentSearches.map((term) => (
                 <button
                   key={term}
-                  className="flex w-full items-center gap-2.5 rounded px-2 py-1.5 text-sm text-text-muted transition-colors hover:bg-surface hover:text-text"
+                  className="flex w-full items-center gap-2.5 rounded-lg px-2 py-1.5 text-sm text-text-muted transition-colors hover:bg-surface hover:text-text"
                   onClick={() => {
                     setQuery(term);
                     setDebouncedQuery(term);
@@ -369,8 +581,8 @@ export function SearchModal() {
             </div>
           )}
 
-          {/* Grouped results */}
-          {hasResults && (
+          {/* Grouped search results */}
+          {hasSearchResults && !isCommandMode && (
             <div className="py-2">
               {sections.map(({ key, label, items }) => (
                 <div key={key} className="mb-1">
@@ -378,8 +590,8 @@ export function SearchModal() {
                     {label}
                   </p>
                   {items.map((item) => {
-                    flatIndex++;
-                    const idx = flatIndex;
+                    globalIndex++;
+                    const idx = globalIndex;
                     const isSelected = idx === selectedIndex;
 
                     return (
@@ -387,7 +599,7 @@ export function SearchModal() {
                         key={item.id}
                         data-result-index={idx}
                         className={cn(
-                          'flex w-full items-center justify-between gap-3 px-4 py-2 text-left transition-colors',
+                          'flex w-full items-center justify-between gap-3 px-4 py-2 text-left transition-colors rounded-lg',
                           isSelected
                             ? 'bg-surface text-text'
                             : 'text-text-muted hover:bg-surface/50 hover:text-text',
@@ -431,6 +643,13 @@ export function SearchModal() {
               esc
             </kbd>
             close
+          </span>
+          <span className="ml-auto flex items-center gap-1 text-[10px] text-text-muted">
+            Type
+            <kbd className="inline-flex h-4 items-center rounded border border-border bg-surface px-1 font-mono text-[9px]">
+              &gt;
+            </kbd>
+            for commands
           </span>
         </div>
       </div>

--- a/web/src/components/sections/calendar-weekly.tsx
+++ b/web/src/components/sections/calendar-weekly.tsx
@@ -1,11 +1,24 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { useQuery } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { cn } from '@/lib/utils';
 
-// ── Date helpers ─────────────────────────────────────
+// ── Constants ───────────────────────────────────────────
+
+const GRID_START_HOUR = 6;
+const GRID_END_HOUR = 23;
+const HOUR_HEIGHT = 60; // px per hour
+const TOTAL_HOURS = GRID_END_HOUR - GRID_START_HOUR;
+const GRID_HEIGHT = TOTAL_HOURS * HOUR_HEIGHT;
+const LABEL_WIDTH = 56; // px for the hour label gutter
+
+// ── Block types to exclude (tasks/priorities/wake) ──────
+
+const EXCLUDED_BLOCK_TYPES = new Set(['mit', 'p1', 'p2', 'task', 'wake']);
+
+// ── Date helpers ────────────────────────────────────────
 
 function getMonday(d: Date): Date {
   const copy = new Date(d);
@@ -37,7 +50,7 @@ function isSameDay(a: Date, b: Date): boolean {
   );
 }
 
-const DAY_LABELS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'] as const;
+const DAY_LABELS = ['MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT', 'SUN'] as const;
 
 const MONTH_NAMES = [
   'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
@@ -58,50 +71,75 @@ function formatWeekRange(monday: Date): string {
   return `${startMonth} ${startDay} \u2013 ${endMonth} ${endDay}, ${year}`;
 }
 
-function formatTime(epochMs: number): string {
-  const d = new Date(epochMs);
-  const h = d.getHours();
-  const m = d.getMinutes();
-  const period = h >= 12 ? 'PM' : 'AM';
-  const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
-  return m === 0 ? `${h12} ${period}` : `${h12}:${String(m).padStart(2, '0')} ${period}`;
+function formatHour(hour: number): string {
+  if (hour === 0 || hour === 24) return '12 AM';
+  if (hour === 12) return '12 PM';
+  if (hour < 12) return `${hour} AM`;
+  return `${hour - 12} PM`;
 }
 
-// ── Block type colors ───────────────────────────────
+function timeToMinutes(time: string): number {
+  const [h, m] = time.split(':').map(Number);
+  return h * 60 + m;
+}
 
-const blockDot: Record<string, string> = {
-  mit: 'bg-accent',
-  p1: 'bg-purple-500',
-  p2: 'bg-indigo-500',
-  event: 'bg-warning',
-  break: 'bg-text-muted/40',
-  lunch: 'bg-text-muted/40',
-  task: 'bg-success',
-  wake: 'bg-warning',
-  other: 'bg-text-muted/40',
+function minutesToPosition(minutes: number): number {
+  const offset = minutes - GRID_START_HOUR * 60;
+  return (offset / 60) * HOUR_HEIGHT;
+}
+
+// ── Block type colors (schedule items only) ─────────────
+
+const blockBorder: Record<string, string> = {
+  event: 'border-l-accent',
+  break: 'border-l-text-muted',
+  lunch: 'border-l-text-muted',
+  other: 'border-l-text-muted',
 };
 
-// ── Types ───────────────────────────────────────────
+const blockBg: Record<string, string> = {
+  event: 'bg-accent/10',
+  break: 'bg-text-muted/5',
+  lunch: 'bg-text-muted/5',
+  other: 'bg-text-muted/5',
+};
 
-interface CalendarEvent {
-  time: string;
+// ── Types ───────────────────────────────────────────────
+
+interface ScheduleBlock {
+  start: string;
+  end: string;
   label: string;
-  type: 'schedule' | 'reminder' | 'task';
-  dotColor: string;
-  sortKey: number; // minutes from midnight or epoch for ordering
+  type: string;
 }
 
-interface DayData {
-  date: Date;
-  dateStr: string;
-  events: CalendarEvent[];
+interface PositionedBlock {
+  top: number;
+  height: number;
+  label: string;
+  type: string;
+  startTime: string;
+  endTime: string;
 }
 
-// ── Main component ──────────────────────────────────
+interface PositionedReminder {
+  top: number;
+  label: string;
+  time: string;
+}
+
+// ── Main component ──────────────────────────────────────
 
 export function CalendarWeekly() {
+  const [now, setNow] = useState(() => new Date());
   const today = useMemo(() => new Date(), []);
   const [weekStart, setWeekStart] = useState(() => getMonday(today));
+
+  // Update "now" every minute for the red line
+  useEffect(() => {
+    const interval = setInterval(() => setNow(new Date()), 60_000);
+    return () => clearInterval(interval);
+  }, []);
 
   const weekDays = useMemo(() => {
     return Array.from({ length: 7 }, (_, i) => addDays(weekStart, i));
@@ -110,35 +148,41 @@ export function CalendarWeekly() {
   const startDate = formatDateStr(weekDays[0]);
   const endDate = formatDateStr(weekDays[6]);
 
-  // Fetch data
+  // Fetch data -- scheduled items only, no tasks
   const reminders = useQuery(api.reminders.list, {});
   const dayPlans = useQuery(api.dayPlans.listByDateRange, { startDate, endDate });
-  const tasks = useQuery(api.tasks.list, { status: 'todo', due: 'all' });
 
-  // Navigation handlers
+  // Navigation
   const goToPrevWeek = () => setWeekStart((prev) => addDays(prev, -7));
   const goToNextWeek = () => setWeekStart((prev) => addDays(prev, 7));
   const goToThisWeek = () => setWeekStart(getMonday(new Date()));
-
   const isThisWeek = isSameDay(weekStart, getMonday(today));
 
-  // Build day data
-  const days: DayData[] = useMemo(() => {
+  // Build positioned blocks per day
+  const dayData = useMemo(() => {
     return weekDays.map((date) => {
       const dateStr = formatDateStr(date);
-      const events: CalendarEvent[] = [];
+      const blocks: PositionedBlock[] = [];
+      const reminderItems: PositionedReminder[] = [];
 
-      // Day plan schedule blocks
-      const plan = dayPlans?.find((p) => p.planDate === dateStr);
+      // Day plan schedule blocks (excluding tasks/priorities/wake)
+      const plan = dayPlans?.find((p: { planDate: string }) => p.planDate === dateStr);
       if (plan) {
-        for (const block of plan.schedule) {
-          const [h, m] = block.start.split(':').map(Number);
-          events.push({
-            time: block.start,
+        for (const block of plan.schedule as ScheduleBlock[]) {
+          if (EXCLUDED_BLOCK_TYPES.has(block.type)) continue;
+
+          const startMin = timeToMinutes(block.start);
+          const endMin = timeToMinutes(block.end);
+          const top = minutesToPosition(startMin);
+          const height = Math.max(((endMin - startMin) / 60) * HOUR_HEIGHT, 20);
+
+          blocks.push({
+            top,
+            height,
             label: block.label,
-            type: 'schedule',
-            dotColor: blockDot[block.type] ?? 'bg-text-muted/40',
-            sortKey: h * 60 + m,
+            type: block.type,
+            startTime: block.start,
+            endTime: block.end,
           });
         }
       }
@@ -159,45 +203,47 @@ export function CalendarWeekly() {
             r.status !== 'done'
           ) {
             const d = new Date(r.scheduledAt);
-            events.push({
-              time: formatTime(r.scheduledAt),
+            const minutes = d.getHours() * 60 + d.getMinutes();
+            const top = minutesToPosition(minutes);
+            const h = d.getHours();
+            const m = d.getMinutes();
+            const period = h >= 12 ? 'PM' : 'AM';
+            const h12 = h === 0 ? 12 : h > 12 ? h - 12 : h;
+            const timeStr = m === 0 ? `${h12} ${period}` : `${h12}:${String(m).padStart(2, '0')} ${period}`;
+
+            reminderItems.push({
+              top,
               label: r.title,
-              type: 'reminder',
-              dotColor: 'bg-danger',
-              sortKey: d.getHours() * 60 + d.getMinutes(),
+              time: timeStr,
             });
           }
         }
       }
 
-      // Tasks with dueDate on this day
-      if (tasks) {
-        for (const t of tasks) {
-          if (t.dueDate === dateStr) {
-            events.push({
-              time: 'All day',
-              label: t.title,
-              type: 'task',
-              dotColor: 'bg-success',
-              sortKey: 9999, // sort after timed events
-            });
-          }
-        }
-      }
-
-      // Sort events by time
-      events.sort((a, b) => a.sortKey - b.sortKey);
-
-      return { date, dateStr, events };
+      return { date, dateStr, blocks, reminders: reminderItems };
     });
-  }, [weekDays, dayPlans, reminders, tasks]);
+  }, [weekDays, dayPlans, reminders]);
 
-  const isLoading = reminders === undefined || dayPlans === undefined || tasks === undefined;
+  const isLoading = reminders === undefined || dayPlans === undefined;
+
+  // "Now" line position
+  const nowMinutes = now.getHours() * 60 + now.getMinutes();
+  const nowTop = minutesToPosition(nowMinutes);
+  const showNowLine =
+    nowMinutes >= GRID_START_HOUR * 60 && nowMinutes <= GRID_END_HOUR * 60;
+
+  // Find which day column is today (if visible this week)
+  const todayIndex = weekDays.findIndex((d) => isSameDay(d, now));
+
+  // Check if there are any items at all
+  const hasAnyItems = dayData.some(
+    (d) => d.blocks.length > 0 || d.reminders.length > 0,
+  );
 
   return (
-    <div className="border border-border">
+    <div className="rounded-xl border border-border bg-surface overflow-hidden">
       {/* Header: navigation */}
-      <div className="flex items-center justify-between px-6 py-4 border-b border-border">
+      <div className="flex items-center justify-between px-6 py-4 border-b border-border bg-bg">
         <button
           onClick={goToPrevWeek}
           className="flex items-center gap-1 text-xs font-mono text-text-muted hover:text-text transition-colors"
@@ -217,7 +263,7 @@ export function CalendarWeekly() {
               onClick={goToThisWeek}
               className="text-[10px] font-bold uppercase tracking-widest text-accent hover:text-text transition-colors border border-accent/30 px-2 py-0.5 rounded"
             >
-              This Week
+              Today
             </button>
           )}
         </div>
@@ -233,162 +279,216 @@ export function CalendarWeekly() {
         </button>
       </div>
 
+      {/* Legend */}
+      <div className="flex items-center gap-4 px-6 py-2 border-b border-border/40">
+        <span className="flex items-center gap-1.5 text-[11px] text-text-muted">
+          {/* Bell icon */}
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-warning">
+            <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+            <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+          </svg>
+          Reminder
+        </span>
+        <span className="flex items-center gap-1.5 text-[11px] text-text-muted">
+          {/* Clock icon */}
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-success">
+            <circle cx="12" cy="12" r="10" />
+            <polyline points="12 6 12 12 16 14" />
+          </svg>
+          Scheduled Job
+        </span>
+        <span className="flex items-center gap-1.5 text-[11px] text-text-muted">
+          {/* Pause icon */}
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-text-muted">
+            <rect x="6" y="4" width="4" height="16" />
+            <rect x="14" y="4" width="4" height="16" />
+          </svg>
+          Break
+        </span>
+        <span className="flex items-center gap-1.5 text-[11px] text-text-muted">
+          {/* Calendar icon */}
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="text-accent">
+            <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+            <line x1="16" y1="2" x2="16" y2="6" />
+            <line x1="8" y1="2" x2="8" y2="6" />
+            <line x1="3" y1="10" x2="21" y2="10" />
+          </svg>
+          Event
+        </span>
+      </div>
+
       {/* Loading state */}
       {isLoading ? (
         <div className="p-6">
-          <div className="grid grid-cols-7 gap-2">
+          <div className="flex gap-2">
+            <div className="w-14 shrink-0" />
             {Array.from({ length: 7 }).map((_, i) => (
-              <div key={i} className="space-y-2">
-                <div className="animate-pulse h-6 bg-surface rounded" />
-                <div className="animate-pulse h-20 bg-surface rounded" />
+              <div key={i} className="flex-1 space-y-2">
+                <div className="animate-pulse h-10 bg-surface-hover rounded" />
+                <div className="animate-pulse h-40 bg-surface-hover rounded" />
               </div>
             ))}
           </div>
         </div>
       ) : (
-        <>
-          {/* Desktop: 7-column grid */}
-          <div className="hidden md:grid grid-cols-7 divide-x divide-border">
-            {days.map((day, i) => {
-              const isToday = isSameDay(day.date, today);
+        <div className="overflow-x-auto">
+          {/* Day headers row */}
+          <div className="flex border-b border-border bg-bg sticky top-0 z-10">
+            {/* Hour gutter spacer */}
+            <div className="shrink-0" style={{ width: LABEL_WIDTH }} />
+
+            {/* Day columns */}
+            {weekDays.map((date, i) => {
+              const isToday = isSameDay(date, now);
               return (
                 <div
-                  key={day.dateStr}
+                  key={i}
                   className={cn(
-                    'min-h-[180px] flex flex-col',
-                    isToday && 'bg-accent/[0.03]',
+                    'flex-1 min-w-[100px] text-center py-2.5 border-l border-border',
+                    isToday && 'bg-accent/[0.04]',
                   )}
                 >
-                  {/* Day header */}
-                  <div
+                  <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted block">
+                    {DAY_LABELS[i]}
+                  </span>
+                  <span
                     className={cn(
-                      'px-3 py-2 border-b text-center',
-                      isToday ? 'border-accent/40 bg-accent/[0.06]' : 'border-border',
+                      'text-lg font-mono block leading-tight',
+                      isToday
+                        ? 'text-accent font-bold'
+                        : 'text-text',
                     )}
                   >
-                    <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
-                      {DAY_LABELS[i]}
-                    </span>
-                    <span
-                      className={cn(
-                        'block text-lg font-mono',
-                        isToday ? 'text-accent font-bold' : 'text-text',
-                      )}
-                    >
-                      {day.date.getDate()}
-                    </span>
-                  </div>
-
-                  {/* Events */}
-                  <div className="flex-1 p-2 space-y-1.5">
-                    {day.events.length === 0 && (
-                      <p className="text-[10px] text-text-muted/40 text-center mt-4 font-mono">
-                        --
-                      </p>
-                    )}
-                    {day.events.map((event, j) => (
-                      <div key={j} className="group">
-                        <div className="flex items-start gap-1.5">
-                          <span
-                            className={cn(
-                              'mt-1.5 h-1.5 w-1.5 rounded-full shrink-0',
-                              event.dotColor,
-                            )}
-                          />
-                          <div className="min-w-0 flex-1">
-                            <span className="text-[10px] font-mono text-text-muted block">
-                              {event.time}
-                            </span>
-                            <span className="text-xs text-text truncate block leading-tight">
-                              {event.label}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+                    {date.getDate()}
+                  </span>
                 </div>
               );
             })}
           </div>
 
-          {/* Mobile: vertical list */}
-          <div className="md:hidden divide-y divide-border">
-            {days.map((day, i) => {
-              const isToday = isSameDay(day.date, today);
-              const hasEvents = day.events.length > 0;
+          {/* Grid body */}
+          <div className="relative flex" style={{ height: GRID_HEIGHT }}>
+            {/* Hour labels gutter */}
+            <div
+              className="shrink-0 relative"
+              style={{ width: LABEL_WIDTH }}
+            >
+              {Array.from({ length: TOTAL_HOURS }).map((_, i) => {
+                const hour = GRID_START_HOUR + i;
+                return (
+                  <div
+                    key={hour}
+                    className="absolute right-2 -translate-y-1/2 text-[10px] font-mono text-text-muted/60"
+                    style={{ top: i * HOUR_HEIGHT }}
+                  >
+                    {formatHour(hour)}
+                  </div>
+                );
+              })}
+            </div>
 
-              if (!hasEvents && !isToday) return null;
-
+            {/* Day columns */}
+            {dayData.map((day, dayIndex) => {
+              const isToday = isSameDay(day.date, now);
               return (
                 <div
                   key={day.dateStr}
                   className={cn(
-                    'px-4 py-3',
-                    isToday && 'bg-accent/[0.03]',
+                    'flex-1 min-w-[100px] relative border-l border-border',
+                    isToday && 'bg-accent/[0.02]',
                   )}
                 >
-                  {/* Day header */}
-                  <div className="flex items-baseline gap-2 mb-2">
-                    <span
-                      className={cn(
-                        'text-sm font-bold',
-                        isToday ? 'text-accent' : 'text-text',
-                      )}
-                    >
-                      {DAY_LABELS[i]} {day.date.getDate()}
-                    </span>
-                    {isToday && (
-                      <span className="text-[10px] font-bold uppercase tracking-widest text-accent">
-                        Today
-                      </span>
-                    )}
-                  </div>
+                  {/* Hour grid lines */}
+                  {Array.from({ length: TOTAL_HOURS }).map((_, i) => (
+                    <div key={`h-${i}`}>
+                      {/* Full hour line */}
+                      <div
+                        className="absolute left-0 right-0 border-t border-border/50"
+                        style={{ top: i * HOUR_HEIGHT }}
+                      />
+                      {/* Half hour line */}
+                      <div
+                        className="absolute left-0 right-0 border-t border-border/25 border-dashed"
+                        style={{ top: i * HOUR_HEIGHT + HOUR_HEIGHT / 2 }}
+                      />
+                    </div>
+                  ))}
+                  {/* Bottom line */}
+                  <div
+                    className="absolute left-0 right-0 border-t border-border/50"
+                    style={{ top: TOTAL_HOURS * HOUR_HEIGHT }}
+                  />
 
-                  {/* Events */}
-                  {day.events.length === 0 ? (
-                    <p className="text-xs text-text-muted/50 font-mono">No events</p>
-                  ) : (
-                    <div className="space-y-2">
-                      {day.events.map((event, j) => (
-                        <div key={j} className="flex items-start gap-2">
-                          <span
-                            className={cn(
-                              'mt-1.5 h-2 w-2 rounded-full shrink-0',
-                              event.dotColor,
-                            )}
-                          />
-                          <div className="flex-1 min-w-0">
-                            <span className="text-xs font-mono text-text-muted">
-                              {event.time}
-                            </span>
-                            <span className="text-sm text-text block truncate">
-                              {event.label}
-                            </span>
-                          </div>
-                        </div>
-                      ))}
+                  {/* Schedule blocks */}
+                  {day.blocks.map((block, bi) => (
+                    <div
+                      key={`b-${bi}`}
+                      className={cn(
+                        'absolute left-1 right-1 rounded px-1.5 py-0.5 border-l-2 overflow-hidden z-[2]',
+                        blockBg[block.type] ?? 'bg-text-muted/5',
+                        blockBorder[block.type] ?? 'border-l-text-muted',
+                      )}
+                      style={{
+                        top: block.top,
+                        height: block.height,
+                      }}
+                      title={`${block.label} (${block.startTime} - ${block.endTime})`}
+                    >
+                      <span className="text-[10px] font-medium text-text leading-tight block truncate">
+                        {block.label}
+                      </span>
+                      {block.height >= 32 && (
+                        <span className="text-[9px] font-mono text-text-muted block truncate">
+                          {block.startTime} - {block.endTime}
+                        </span>
+                      )}
+                    </div>
+                  ))}
+
+                  {/* Reminder items */}
+                  {day.reminders.map((reminder, ri) => (
+                    <div
+                      key={`r-${ri}`}
+                      className="absolute left-1 right-1 rounded px-1.5 py-0.5 border-l-2 border-l-warning bg-warning/10 overflow-hidden z-[3]"
+                      style={{
+                        top: reminder.top,
+                        height: 24,
+                      }}
+                      title={`Reminder: ${reminder.label} at ${reminder.time}`}
+                    >
+                      <span className="text-[10px] font-medium text-text leading-tight block truncate">
+                        {reminder.label}
+                      </span>
+                    </div>
+                  ))}
+
+                  {/* Red "now" line -- only on today's column */}
+                  {isToday && showNowLine && (
+                    <div
+                      className="absolute left-0 right-0 z-[5] pointer-events-none"
+                      style={{ top: nowTop }}
+                    >
+                      <div className="relative">
+                        <div className="absolute left-0 top-1/2 -translate-y-1/2 -translate-x-1/2 w-2 h-2 rounded-full bg-danger" />
+                        <div className="absolute left-0 right-0 border-t-2 border-danger" />
+                      </div>
                     </div>
                   )}
                 </div>
               );
             })}
           </div>
-        </>
-      )}
 
-      {/* Legend */}
-      <div className="flex items-center gap-4 px-6 py-3 border-t border-border">
-        <span className="flex items-center gap-1.5 text-[10px] text-text-muted">
-          <span className="h-1.5 w-1.5 rounded-full bg-accent" /> Schedule
-        </span>
-        <span className="flex items-center gap-1.5 text-[10px] text-text-muted">
-          <span className="h-1.5 w-1.5 rounded-full bg-danger" /> Reminder
-        </span>
-        <span className="flex items-center gap-1.5 text-[10px] text-text-muted">
-          <span className="h-1.5 w-1.5 rounded-full bg-success" /> Task
-        </span>
-      </div>
+          {/* Empty state overlay */}
+          {!hasAnyItems && (
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none" style={{ top: 120 }}>
+              <p className="text-xs text-text-muted/40 font-mono">
+                No scheduled items this week
+              </p>
+            </div>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/components/sections/day-nav.tsx
+++ b/web/src/components/sections/day-nav.tsx
@@ -2,13 +2,22 @@
 
 import { useTodayDate } from '@/lib/today-date-context';
 
+function getOrdinalSuffix(day: number): string {
+  if (day >= 11 && day <= 13) return 'th';
+  switch (day % 10) {
+    case 1: return 'st';
+    case 2: return 'nd';
+    case 3: return 'rd';
+    default: return 'th';
+  }
+}
+
 function formatNavDate(dateStr: string): string {
   const d = new Date(dateStr + 'T12:00:00');
-  return d.toLocaleDateString('en-US', {
-    weekday: 'short',
-    month: 'short',
-    day: 'numeric',
-  });
+  const weekday = d.toLocaleDateString('en-US', { weekday: 'long' });
+  const month = d.toLocaleDateString('en-US', { month: 'long' });
+  const day = d.getDate();
+  return `${weekday}, ${month} ${day}${getOrdinalSuffix(day)}`;
 }
 
 export function DayNav() {
@@ -38,8 +47,8 @@ export function DayNav() {
         </button>
 
         {/* Current date */}
-        <span className="font-mono text-sm font-bold text-text tracking-wide">
-          [ {formatNavDate(date)} ]
+        <span className="text-lg font-semibold text-text">
+          {formatNavDate(date)}
         </span>
 
         {/* Next day */}
@@ -68,7 +77,7 @@ export function DayNav() {
         <div className="flex justify-center mt-3">
           <button
             onClick={goToday}
-            className="border border-accent/40 px-3 py-1 text-xs font-bold text-accent uppercase tracking-wide transition-colors hover:bg-accent/10"
+            className="rounded-lg border border-accent/40 px-3 py-1 text-xs font-bold text-accent uppercase tracking-wide transition-colors hover:bg-accent/10"
           >
             Back to Today
           </button>

--- a/web/src/components/sections/day-plan.tsx
+++ b/web/src/components/sections/day-plan.tsx
@@ -45,11 +45,17 @@ export function DayPlan() {
   const dayPlan = useQuery(api.dayPlans.getByDate, { date: today() });
 
   if (dayPlan === undefined) {
-    return <div className="text-text-muted">Loading...</div>;
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-16 rounded-xl bg-surface animate-pulse" />
+        ))}
+      </div>
+    );
   }
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-baseline justify-between">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">Today</h2>
         <span className="text-xs font-mono text-text-muted">{formatDate(today())}</span>
@@ -101,7 +107,7 @@ export function DayPlan() {
 
           {/* Overflow */}
           {dayPlan.overflow && dayPlan.overflow.length > 0 && (
-            <div className="border border-warning/30 px-4 py-3">
+            <div className="border border-warning/30 rounded-xl px-4 py-3">
               <p className="text-xs font-bold text-warning uppercase tracking-wide">Overflow</p>
               <p className="text-xs text-text-muted mt-1">
                 {dayPlan.overflow.length} task(s) did not fit in today&apos;s schedule.

--- a/web/src/components/sections/day-timeline.tsx
+++ b/web/src/components/sections/day-timeline.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
+import type { Id } from '@/lib/convex-api';
 import { useTodayDate } from '@/lib/today-date-context';
 import { cn } from '@/lib/utils';
 
-// ── Block type colors (reuse the same palette as day-plan.tsx) ──
+// ── Block type colors ────────────────────────────────────
 
 const blockBorder: Record<string, string> = {
   mit: 'border-l-accent',
@@ -20,13 +21,66 @@ const blockBorder: Record<string, string> = {
   other: 'border-l-text-muted',
 };
 
+const blockBg: Record<string, string> = {
+  mit: 'bg-accent/10',
+  p1: 'bg-purple-500/10',
+  p2: 'bg-indigo-500/10',
+  event: 'bg-warning/10',
+  break: 'bg-text-muted/5',
+  lunch: 'bg-text-muted/5',
+  task: 'bg-success/10',
+  wake: 'bg-warning/10',
+  other: 'bg-text-muted/5',
+};
+
 const checkableTypes = new Set(['mit', 'p1', 'p2', 'task']);
+
+// ── Constants ────────────────────────────────────────────
+
+const GRID_START_HOUR = 6;
+const GRID_END_HOUR = 23;
+const HOUR_HEIGHT = 60; // px per hour
+const TOTAL_HOURS = GRID_END_HOUR - GRID_START_HOUR;
+const GRID_HEIGHT = TOTAL_HOURS * HOUR_HEIGHT;
+const LABEL_WIDTH = 56; // px for the hour label gutter
+const RESIZE_HANDLE_HEIGHT = 8; // px
+const MIN_DURATION_MINUTES = 15;
 
 // ── Helpers ──────────────────────────────────────────────
 
 function timeToMinutes(time: string): number {
   const [h, m] = time.split(':').map(Number);
   return h * 60 + m;
+}
+
+function minutesToPosition(minutes: number): number {
+  const offset = minutes - GRID_START_HOUR * 60;
+  return (offset / 60) * HOUR_HEIGHT;
+}
+
+function minutesToTimeString(totalMinutes: number): string {
+  const h = Math.floor(totalMinutes / 60);
+  const m = totalMinutes % 60;
+  return `${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}`;
+}
+
+function snapToQuarter(minutes: number): number {
+  return Math.round(minutes / 15) * 15;
+}
+
+function clampMinutes(minutes: number): number {
+  return Math.max(GRID_START_HOUR * 60, Math.min(minutes, GRID_END_HOUR * 60));
+}
+
+function positionToMinutes(y: number): number {
+  return (y / HOUR_HEIGHT) * 60 + GRID_START_HOUR * 60;
+}
+
+function formatHour(hour: number): string {
+  if (hour === 0 || hour === 24) return '12 AM';
+  if (hour === 12) return '12 PM';
+  if (hour < 12) return `${hour} AM`;
+  return `${hour - 12} PM`;
 }
 
 function getDoneField(type: string): 'mitDone' | 'p1Done' | 'p2Done' | null {
@@ -51,7 +105,7 @@ function getDoneValue(
   return dayPlan[field];
 }
 
-// ── ScheduleBlock ────────────────────────────────────────
+// ── ScheduleBlock type ───────────────────────────────────
 
 interface ScheduleBlock {
   start: string;
@@ -61,92 +115,275 @@ interface ScheduleBlock {
   taskId?: string;
 }
 
-function BlockRow({
+// ── Resize state type ───────────────────────────────────
+
+interface ResizeState {
+  blockIndex: number;
+  edge: 'bottom' | 'top';
+  initialMouseY: number;
+  initialStartMin: number;
+  initialEndMin: number;
+}
+
+// ── EventCard (positioned block on the grid) ─────────────
+
+function EventCard({
   block,
-  isPast,
-  isCurrent,
+  blockIndex,
   done,
   onToggle,
+  onResizeStart,
+  overrideStartMin,
+  overrideEndMin,
+  isResizing,
 }: {
   block: ScheduleBlock;
-  isPast: boolean;
-  isCurrent: boolean;
+  blockIndex: number;
   done: boolean;
   onToggle: (() => void) | null;
+  onResizeStart: (e: React.MouseEvent, blockIndex: number, edge: 'bottom' | 'top') => void;
+  overrideStartMin?: number;
+  overrideEndMin?: number;
+  isResizing: boolean;
 }) {
+  const startMin = overrideStartMin ?? timeToMinutes(block.start);
+  const endMin = overrideEndMin ?? timeToMinutes(block.end);
+  const top = minutesToPosition(startMin);
+  const height = Math.max(((endMin - startMin) / 60) * HOUR_HEIGHT, 20);
+
+  const formatTime = (t: string) => {
+    const [h, m] = t.split(':').map(Number);
+    const suffix = h >= 12 ? 'PM' : 'AM';
+    const displayH = h === 0 ? 12 : h > 12 ? h - 12 : h;
+    return `${displayH}:${m.toString().padStart(2, '0')} ${suffix}`;
+  };
+
+  const displayStart = overrideStartMin != null ? minutesToTimeString(overrideStartMin) : block.start;
+  const displayEnd = overrideEndMin != null ? minutesToTimeString(overrideEndMin) : block.end;
+
+  const handleDragStart = (e: React.DragEvent) => {
+    // Don't start drag if we're resizing
+    if (isResizing) {
+      e.preventDefault();
+      return;
+    }
+    e.dataTransfer.setData('application/x-timeline-block-index', String(blockIndex));
+    e.dataTransfer.setData('application/x-block-label', block.label);
+    e.dataTransfer.setData('application/x-block-type', block.type);
+    e.dataTransfer.setData('application/x-block-task-id', block.taskId ?? '');
+    const duration = timeToMinutes(block.end) - timeToMinutes(block.start);
+    e.dataTransfer.setData('application/x-block-duration', String(duration));
+    e.dataTransfer.effectAllowed = 'move';
+  };
+
   return (
     <div
+      draggable={!isResizing}
+      onDragStart={handleDragStart}
       className={cn(
-        'flex items-center gap-4 border-l-2 px-4 py-3 transition-colors',
+        'absolute left-0 right-0 rounded-lg border-l-[3px] px-3 py-1.5 overflow-hidden transition-opacity select-none group',
         blockBorder[block.type] ?? 'border-l-text-muted',
-        isPast && 'opacity-50',
-        isCurrent && 'bg-danger/5',
+        blockBg[block.type] ?? 'bg-text-muted/5',
+        done && 'opacity-50',
+        isResizing ? 'cursor-ns-resize z-30' : 'cursor-grab active:cursor-grabbing',
       )}
+      style={{
+        top: `${top}px`,
+        height: `${height}px`,
+      }}
     >
-      {/* Time range */}
-      <span className="w-28 shrink-0 font-mono text-xs text-text-muted">
-        {block.start} - {block.end}
-      </span>
+      {/* Top resize handle */}
+      <div
+        className="absolute top-0 left-0 right-0 cursor-n-resize z-10"
+        style={{ height: `${RESIZE_HANDLE_HEIGHT}px` }}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onResizeStart(e, blockIndex, 'top');
+        }}
+      />
 
-      {/* Optional checkbox for priority/task blocks */}
-      {onToggle ? (
-        <button
-          onClick={onToggle}
-          className={cn(
-            'flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-all',
-            done
-              ? 'border-success bg-success text-white'
-              : 'border-text-muted/40 hover:border-text',
-          )}
-          aria-label={`Toggle ${block.label}`}
-        >
-          {done && (
-            <svg
-              width="10"
-              height="10"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="3"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-          )}
-        </button>
-      ) : (
-        <span className="w-4 shrink-0" />
-      )}
-
-      {/* Label */}
-      <span
-        className={cn(
-          'flex-1 text-sm truncate',
-          done ? 'line-through text-text-muted' : 'text-text',
+      <div className="flex items-start gap-2 h-full">
+        {/* Checkbox for checkable types */}
+        {onToggle && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle();
+            }}
+            className={cn(
+              'flex h-4 w-4 shrink-0 items-center justify-center rounded-sm border transition-all mt-0.5',
+              done
+                ? 'border-success bg-success text-white'
+                : 'border-text-muted/40 hover:border-text',
+            )}
+            aria-label={`Toggle ${block.label}`}
+          >
+            {done && (
+              <svg
+                width="10"
+                height="10"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="3"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            )}
+          </button>
         )}
-      >
-        {block.label}
-      </span>
 
-      {/* Type badge */}
-      <span className="text-xs font-mono text-text-muted uppercase">
-        {block.type}
-      </span>
+        <div className="flex-1 min-w-0">
+          <p
+            className={cn(
+              'text-sm font-medium truncate leading-tight',
+              done ? 'line-through text-text-muted' : 'text-text',
+            )}
+          >
+            {block.label}
+          </p>
+          {height >= 36 && (
+            <p className="text-xs text-text-muted mt-0.5">
+              {formatTime(displayStart)} - {formatTime(displayEnd)}
+            </p>
+          )}
+        </div>
+      </div>
+
+      {/* Bottom resize handle */}
+      <div
+        className="absolute bottom-0 left-0 right-0 cursor-s-resize z-10"
+        style={{ height: `${RESIZE_HANDLE_HEIGHT}px` }}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          onResizeStart(e, blockIndex, 'bottom');
+        }}
+      />
+
+      {/* Visual resize indicator on hover */}
+      <div className="absolute bottom-0 left-2 right-2 h-1 rounded-full bg-text-muted/0 group-hover:bg-text-muted/30 transition-colors" />
     </div>
   );
 }
 
-// ── NowLine ──────────────────────────────────────────────
+// ── NowLine (red current-time indicator) ─────────────────
 
-function NowLine() {
+function NowIndicator({ nowMinutes }: { nowMinutes: number }) {
+  const top = minutesToPosition(nowMinutes);
+
+  // Only show if within the grid bounds
+  if (top < 0 || top > GRID_HEIGHT) return null;
+
   return (
-    <div className="relative flex items-center gap-2 py-1">
-      <span className="h-2 w-2 rounded-full bg-danger shrink-0" />
-      <span className="text-xs font-bold text-danger uppercase tracking-widest">
-        Now
-      </span>
-      <div className="flex-1 h-px bg-danger" />
+    <div
+      className="absolute left-0 right-0 z-20 pointer-events-none"
+      style={{ top: `${top}px` }}
+    >
+      {/* Red circle on the left edge */}
+      <div className="absolute -left-[5px] -top-[5px] h-[10px] w-[10px] rounded-full bg-danger" />
+      {/* Red line across the width */}
+      <div className="h-[2px] bg-danger w-full" />
+    </div>
+  );
+}
+
+// ── TaskSidebarCard ──────────────────────────────────────
+
+function TaskSidebarCard({ task }: { task: { _id: Id<'tasks'>; title: string } }) {
+  const handleDragStart = (e: React.DragEvent) => {
+    e.dataTransfer.setData('application/x-task-id', task._id);
+    e.dataTransfer.setData('application/x-task-title', task.title);
+    e.dataTransfer.effectAllowed = 'copy';
+  };
+
+  return (
+    <div
+      draggable
+      onDragStart={handleDragStart}
+      className="rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text truncate cursor-grab active:cursor-grabbing hover:border-accent/50 transition-colors"
+      title={task.title}
+    >
+      {task.title}
+    </div>
+  );
+}
+
+// ── TaskSidebar ──────────────────────────────────────────
+
+function TaskSidebar({
+  todayTasks,
+  overdueTasks,
+  isDragOverSidebar,
+  onSidebarDragOver,
+  onSidebarDragLeave,
+  onSidebarDrop,
+}: {
+  todayTasks: { _id: Id<'tasks'>; title: string }[] | undefined;
+  overdueTasks: { _id: Id<'tasks'>; title: string }[] | undefined;
+  isDragOverSidebar: boolean;
+  onSidebarDragOver: (e: React.DragEvent) => void;
+  onSidebarDragLeave: () => void;
+  onSidebarDrop: (e: React.DragEvent) => void;
+}) {
+  const todayCount = todayTasks?.length ?? 0;
+  const overdueCount = overdueTasks?.length ?? 0;
+  const isEmpty = todayCount === 0 && overdueCount === 0;
+
+  return (
+    <div
+      className={cn(
+        'shrink-0 w-[200px] border-l border-border overflow-y-auto max-h-[660px] transition-colors',
+        isDragOverSidebar && 'bg-danger/10 border-l-danger/50',
+      )}
+      onDragOver={onSidebarDragOver}
+      onDragLeave={onSidebarDragLeave}
+      onDrop={onSidebarDrop}
+    >
+      <div className="p-3 space-y-4">
+        {/* Drop-to-remove indicator */}
+        {isDragOverSidebar && (
+          <div className="rounded-lg border-2 border-dashed border-danger/40 px-3 py-3 text-center">
+            <p className="text-xs font-bold text-danger">Remove from schedule</p>
+          </div>
+        )}
+
+        {/* Overdue section */}
+        {overdueCount > 0 && (
+          <div>
+            <h3 className="text-xs font-bold text-danger uppercase tracking-wide mb-2">
+              Overdue ({overdueCount})
+            </h3>
+            <div className="space-y-1.5">
+              {overdueTasks!.map((task) => (
+                <TaskSidebarCard key={task._id} task={task} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Today section */}
+        {todayCount > 0 && (
+          <div>
+            <h3 className="text-xs font-bold text-text-muted uppercase tracking-wide mb-2">
+              Today ({todayCount})
+            </h3>
+            <div className="space-y-1.5">
+              {todayTasks!.map((task) => (
+                <TaskSidebarCard key={task._id} task={task} />
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Empty state */}
+        {isEmpty && !isDragOverSidebar && (
+          <p className="text-xs text-text-muted text-center py-4">No tasks</p>
+        )}
+      </div>
     </div>
   );
 }
@@ -158,7 +395,23 @@ export function DayTimeline() {
   const dayPlan = useQuery(api.dayPlans.getByDate, { date });
   const upsert = useMutation(api.dayPlans.upsert);
 
+  const todayTasks = useQuery(api.tasks.list, { status: 'todo', due: 'today' });
+  const overdueTasks = useQuery(api.tasks.list, { status: 'todo', due: 'overdue' });
+
   const [now, setNow] = useState(() => new Date());
+  const [dropTargetMinutes, setDropTargetMinutes] = useState<number | null>(null);
+
+  // Resize state
+  const [resizing, setResizing] = useState<ResizeState | null>(null);
+  const [resizePreview, setResizePreview] = useState<{ startMin: number; endMin: number } | null>(null);
+
+  // Drag-to-reposition state
+  const [blockDropTargetMinutes, setBlockDropTargetMinutes] = useState<number | null>(null);
+
+  // Sidebar drop state
+  const [isDragOverSidebar, setIsDragOverSidebar] = useState(false);
+
+  const gridRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (!isToday) return;
@@ -168,22 +421,211 @@ export function DayTimeline() {
 
   const nowMinutes = now.getHours() * 60 + now.getMinutes();
 
+  const schedule: ScheduleBlock[] = dayPlan?.schedule ?? [];
+
+  // ── Resize handlers (native mouse events) ──────────────
+
+  const handleResizeStart = useCallback(
+    (e: React.MouseEvent, blockIndex: number, edge: 'bottom' | 'top') => {
+      const block = schedule[blockIndex];
+      if (!block) return;
+
+      setResizing({
+        blockIndex,
+        edge,
+        initialMouseY: e.clientY,
+        initialStartMin: timeToMinutes(block.start),
+        initialEndMin: timeToMinutes(block.end),
+      });
+      setResizePreview({
+        startMin: timeToMinutes(block.start),
+        endMin: timeToMinutes(block.end),
+      });
+    },
+    [schedule],
+  );
+
+  useEffect(() => {
+    if (!resizing) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!gridRef.current) return;
+      const rect = gridRef.current.getBoundingClientRect();
+      const mouseY = e.clientY - rect.top;
+      const mouseMinutes = snapToQuarter(positionToMinutes(mouseY));
+
+      if (resizing.edge === 'bottom') {
+        const newEnd = clampMinutes(mouseMinutes);
+        const minEnd = resizing.initialStartMin + MIN_DURATION_MINUTES;
+        setResizePreview({
+          startMin: resizing.initialStartMin,
+          endMin: Math.max(newEnd, minEnd),
+        });
+      } else {
+        const newStart = clampMinutes(mouseMinutes);
+        const maxStart = resizing.initialEndMin - MIN_DURATION_MINUTES;
+        setResizePreview({
+          startMin: Math.min(newStart, maxStart),
+          endMin: resizing.initialEndMin,
+        });
+      }
+    };
+
+    const handleMouseUp = () => {
+      if (resizePreview && dayPlan) {
+        const updatedSchedule = [...schedule];
+        updatedSchedule[resizing.blockIndex] = {
+          ...updatedSchedule[resizing.blockIndex],
+          start: minutesToTimeString(resizePreview.startMin),
+          end: minutesToTimeString(resizePreview.endMin),
+        };
+        void upsert({ date, schedule: updatedSchedule });
+      }
+      setResizing(null);
+      setResizePreview(null);
+    };
+
+    window.addEventListener('mousemove', handleMouseMove);
+    window.addEventListener('mouseup', handleMouseUp);
+    return () => {
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.removeEventListener('mouseup', handleMouseUp);
+    };
+  }, [resizing, resizePreview, schedule, dayPlan, date, upsert]);
+
+  // ── Grid drag handlers (for both sidebar tasks and timeline block repositioning) ──
+
+  const calcDropMinutes = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    const rect = e.currentTarget.getBoundingClientRect();
+    const dropY = e.clientY - rect.top;
+    const rawMinutes = positionToMinutes(dropY);
+    return snapToQuarter(rawMinutes);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      const hasTask = e.dataTransfer.types.includes('application/x-task-id');
+      const hasBlock = e.dataTransfer.types.includes('application/x-timeline-block-index');
+
+      if (!hasTask && !hasBlock) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = hasBlock ? 'move' : 'copy';
+
+      const minutes = calcDropMinutes(e);
+
+      if (hasBlock) {
+        setBlockDropTargetMinutes(minutes);
+      } else {
+        setDropTargetMinutes(minutes);
+      }
+    },
+    [calcDropMinutes],
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setDropTargetMinutes(null);
+    setBlockDropTargetMinutes(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      setDropTargetMinutes(null);
+      setBlockDropTargetMinutes(null);
+
+      // Case 1: Dropping a timeline block to reposition
+      const blockIndexStr = e.dataTransfer.getData('application/x-timeline-block-index');
+      if (blockIndexStr !== '') {
+        const blockIndex = Number(blockIndexStr);
+        const durationStr = e.dataTransfer.getData('application/x-block-duration');
+        const duration = Number(durationStr) || 60;
+        const dropMinutes = calcDropMinutes(e);
+
+        const newStart = clampMinutes(dropMinutes);
+        const newEnd = clampMinutes(newStart + duration);
+
+        // If the end got clamped, adjust the start to maintain duration
+        const actualEnd = Math.min(newEnd, GRID_END_HOUR * 60);
+        const actualStart = Math.max(actualEnd - duration, GRID_START_HOUR * 60);
+
+        const updatedSchedule = [...schedule];
+        updatedSchedule[blockIndex] = {
+          ...updatedSchedule[blockIndex],
+          start: minutesToTimeString(actualStart),
+          end: minutesToTimeString(actualEnd),
+        };
+        void upsert({ date, schedule: updatedSchedule });
+        return;
+      }
+
+      // Case 2: Dropping a task from the sidebar
+      const taskId = e.dataTransfer.getData('application/x-task-id');
+      const taskTitle = e.dataTransfer.getData('application/x-task-title');
+      if (!taskId || !taskTitle) return;
+
+      const startMinutes = calcDropMinutes(e);
+      const endMinutes = startMinutes + 60;
+
+      const clampedStart = Math.max(GRID_START_HOUR * 60, Math.min(startMinutes, (GRID_END_HOUR - 1) * 60));
+      const clampedEnd = Math.min(GRID_END_HOUR * 60, endMinutes);
+
+      const newBlock: ScheduleBlock = {
+        start: minutesToTimeString(clampedStart),
+        end: minutesToTimeString(clampedEnd),
+        label: taskTitle,
+        type: 'task',
+        taskId,
+      };
+
+      const existingSchedule: ScheduleBlock[] = dayPlan?.schedule ?? [];
+      void upsert({ date, schedule: [...existingSchedule, newBlock] });
+    },
+    [calcDropMinutes, dayPlan, date, upsert, schedule],
+  );
+
+  // ── Sidebar drag handlers (drop block to remove from schedule) ──
+
+  const handleSidebarDragOver = useCallback((e: React.DragEvent) => {
+    if (!e.dataTransfer.types.includes('application/x-timeline-block-index')) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setIsDragOverSidebar(true);
+  }, []);
+
+  const handleSidebarDragLeave = useCallback(() => {
+    setIsDragOverSidebar(false);
+  }, []);
+
+  const handleSidebarDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setIsDragOverSidebar(false);
+
+      const blockIndexStr = e.dataTransfer.getData('application/x-timeline-block-index');
+      if (blockIndexStr === '') return;
+
+      const blockIndex = Number(blockIndexStr);
+      const updatedSchedule = schedule.filter((_, i) => i !== blockIndex);
+      void upsert({ date, schedule: updatedSchedule });
+    },
+    [schedule, date, upsert],
+  );
+
+  // Loading state
   if (dayPlan === undefined) {
     return (
-      <div className="border border-border">
+      <div className="rounded-xl border border-border bg-surface">
         <div className="px-6 py-4 border-b border-border">
-          <div className="animate-pulse h-4 w-28 bg-surface rounded" />
+          <div className="animate-pulse h-4 w-28 bg-bg-subtle rounded" />
         </div>
         <div className="p-6 space-y-2">
           {Array.from({ length: 6 }).map((_, i) => (
-            <div key={i} className="animate-pulse h-10 bg-surface rounded" />
+            <div key={i} className="animate-pulse h-10 bg-bg-subtle rounded" />
           ))}
         </div>
       </div>
     );
   }
-
-  const schedule: ScheduleBlock[] = dayPlan?.schedule ?? [];
 
   const handleToggle = (type: string) => {
     const field = getDoneField(type);
@@ -191,45 +633,12 @@ export function DayTimeline() {
     void upsert({ date, [field]: !dayPlan[field] });
   };
 
-  // Build render list with NOW line insertions
-  type RenderItem =
-    | { kind: 'block'; block: ScheduleBlock; index: number }
-    | { kind: 'now' };
-
-  const items: RenderItem[] = [];
-  let nowInserted = false;
-
-  for (let i = 0; i < schedule.length; i++) {
-    const block = schedule[i];
-
-    // Insert NOW line before this block if now falls before its start
-    if (isToday && !nowInserted && nowMinutes < timeToMinutes(block.start)) {
-      items.push({ kind: 'now' });
-      nowInserted = true;
-    }
-
-    items.push({ kind: 'block', block, index: i });
-
-    // Insert NOW line between blocks if now falls in the gap
-    if (isToday && !nowInserted) {
-      const nextBlock = schedule[i + 1];
-      const blockEnd = timeToMinutes(block.end);
-      if (nowMinutes >= blockEnd) {
-        if (!nextBlock || nowMinutes < timeToMinutes(nextBlock.start)) {
-          items.push({ kind: 'now' });
-          nowInserted = true;
-        }
-      }
-    }
-  }
-
-  // If NOW hasn't been inserted yet and it's today, append it at the end
-  if (isToday && !nowInserted) {
-    items.push({ kind: 'now' });
-  }
+  // Build the hour labels array
+  const hours = Array.from({ length: TOTAL_HOURS }, (_, i) => GRID_START_HOUR + i);
 
   return (
-    <div className="border border-border">
+    <div className="rounded-xl border border-border bg-surface overflow-hidden">
+      {/* Header */}
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Timeline
@@ -241,43 +650,136 @@ export function DayTimeline() {
         )}
       </div>
 
-      {schedule.length > 0 ? (
-        <div className="py-2">
-          {items.map((item) => {
-            if (item.kind === 'now') {
-              return <div key="now-line" className="px-4"><NowLine /></div>;
-            }
+      {/* Calendar grid + task sidebar */}
+      <div className="flex overflow-hidden">
+        <div className="flex-1 overflow-y-auto max-h-[660px]">
+          <div className="flex" style={{ minHeight: `${GRID_HEIGHT}px` }}>
+            {/* Hour labels gutter */}
+            <div
+              className="shrink-0 border-r border-border"
+              style={{ width: `${LABEL_WIDTH}px` }}
+            >
+              {hours.map((hour) => (
+                <div
+                  key={hour}
+                  className="relative"
+                  style={{ height: `${HOUR_HEIGHT}px` }}
+                >
+                  <span className="absolute -top-[9px] right-3 text-[11px] text-text-muted select-none">
+                    {formatHour(hour)}
+                  </span>
+                </div>
+              ))}
+            </div>
 
-            const { block, index } = item;
-            const blockStart = timeToMinutes(block.start);
-            const blockEnd = timeToMinutes(block.end);
-            const isPast = isToday && nowMinutes >= blockEnd;
-            const isCurrent =
-              isToday && nowMinutes >= blockStart && nowMinutes < blockEnd;
+            {/* Grid area with events */}
+            <div
+              ref={gridRef}
+              className={cn(
+                'flex-1 relative',
+                resizing && 'cursor-ns-resize',
+              )}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+            >
+              {/* Hour grid lines */}
+              {hours.map((hour) => (
+                <div
+                  key={hour}
+                  className="absolute left-0 right-0 border-t border-border"
+                  style={{ top: `${(hour - GRID_START_HOUR) * HOUR_HEIGHT}px` }}
+                />
+              ))}
 
-            const isCheckable = checkableTypes.has(block.type);
-            const done = dayPlan ? getDoneValue(dayPlan, block.type) : false;
+              {/* Half-hour dashed lines */}
+              {hours.map((hour) => (
+                <div
+                  key={`half-${hour}`}
+                  className="absolute left-0 right-0 border-t border-border/40 border-dashed"
+                  style={{
+                    top: `${(hour - GRID_START_HOUR) * HOUR_HEIGHT + HOUR_HEIGHT / 2}px`,
+                  }}
+                />
+              ))}
 
-            return (
-              <BlockRow
-                key={`block-${index}`}
-                block={block}
-                isPast={isPast}
-                isCurrent={isCurrent}
-                done={done}
-                onToggle={isCheckable ? () => handleToggle(block.type) : null}
-              />
-            );
-          })}
+              {/* Drop indicator for sidebar tasks */}
+              {dropTargetMinutes !== null && (
+                <div
+                  className="absolute left-0 right-0 bg-accent/15 border border-accent/30 rounded pointer-events-none z-10"
+                  style={{
+                    top: `${minutesToPosition(dropTargetMinutes)}px`,
+                    height: `${HOUR_HEIGHT}px`,
+                  }}
+                />
+              )}
+
+              {/* Drop indicator for repositioning timeline blocks */}
+              {blockDropTargetMinutes !== null && (
+                <div
+                  className="absolute left-0 right-0 bg-success/15 border border-success/30 rounded pointer-events-none z-10"
+                  style={{
+                    top: `${minutesToPosition(blockDropTargetMinutes)}px`,
+                    height: `${HOUR_HEIGHT}px`,
+                  }}
+                />
+              )}
+
+              {/* Event blocks */}
+              <div className="absolute inset-0 px-2">
+                {schedule.map((block, index) => {
+                  const isCheckable = checkableTypes.has(block.type);
+                  const done = dayPlan ? getDoneValue(dayPlan, block.type) : false;
+                  const isBeingResized = resizing?.blockIndex === index;
+
+                  return (
+                    <EventCard
+                      key={`block-${index}`}
+                      block={block}
+                      blockIndex={index}
+                      done={done}
+                      onToggle={isCheckable ? () => handleToggle(block.type) : null}
+                      onResizeStart={handleResizeStart}
+                      overrideStartMin={isBeingResized ? resizePreview?.startMin : undefined}
+                      overrideEndMin={isBeingResized ? resizePreview?.endMin : undefined}
+                      isResizing={isBeingResized}
+                    />
+                  );
+                })}
+              </div>
+
+              {/* Now line */}
+              {isToday && <NowIndicator nowMinutes={nowMinutes} />}
+
+              {/* Empty state message */}
+              {schedule.length === 0 && (
+                <div
+                  className="absolute inset-x-0 flex flex-col items-center justify-center pointer-events-none"
+                  style={{
+                    top: `${2 * HOUR_HEIGHT}px`,
+                    height: `${2 * HOUR_HEIGHT}px`,
+                  }}
+                >
+                  <p className="text-sm text-text-muted">No events scheduled</p>
+                  <p className="text-xs text-text-muted/60 mt-1">
+                    Drag tasks from the sidebar or create a day plan
+                  </p>
+                </div>
+              )}
+            </div>
+          </div>
         </div>
-      ) : (
-        <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
-          <p className="text-sm text-text-muted">No schedule blocks</p>
-          <p className="text-xs text-text-muted/60 mt-1">
-            Create a day plan to populate the timeline
-          </p>
-        </div>
-      )}
+
+        {/* Task sidebar */}
+        <TaskSidebar
+          todayTasks={todayTasks}
+          overdueTasks={overdueTasks}
+          isDragOverSidebar={isDragOverSidebar}
+          onSidebarDragOver={handleSidebarDragOver}
+          onSidebarDragLeave={handleSidebarDragLeave}
+          onSidebarDrop={handleSidebarDrop}
+        />
+      </div>
 
       {/* Overflow warning */}
       {dayPlan?.overflow && dayPlan.overflow.length > 0 && (

--- a/web/src/components/sections/focus-rings.tsx
+++ b/web/src/components/sections/focus-rings.tsx
@@ -41,7 +41,7 @@ export function FocusRings() {
         {focusItems.map((item) => (
           <div
             key={item.label}
-            className="border border-border p-6 flex flex-col items-center gap-4"
+            className="border border-border rounded-xl p-6 flex flex-col items-center gap-4"
           >
             <span className="text-xs font-bold text-text-muted uppercase tracking-widest">
               {item.label}

--- a/web/src/components/sections/goals-at-risk.tsx
+++ b/web/src/components/sections/goals-at-risk.tsx
@@ -62,7 +62,7 @@ export function GoalsAtRisk() {
 
   if (goals.length === 0) {
     return (
-      <div className="border border-border p-6">
+      <div className="border border-border rounded-xl p-6">
         <div className="flex items-baseline justify-between mb-4">
           <h2 className="text-sm font-bold text-text uppercase tracking-wide">
             Goals at Risk
@@ -74,7 +74,7 @@ export function GoalsAtRisk() {
   }
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Goals at Risk

--- a/web/src/components/sections/goals-grid.tsx
+++ b/web/src/components/sections/goals-grid.tsx
@@ -4,7 +4,7 @@ import { useQuery } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { GoalForm } from '@/components/goal-form';
 import Link from 'next/link';
-import type { Doc } from '../../../../../convex/_generated/dataModel';
+import type { Doc } from '@/lib/convex-api';
 
 const healthColor: Record<string, string> = {
   on_track: 'bg-success',
@@ -40,7 +40,7 @@ function GoalCard({ goal }: { goal: Doc<"goals"> }) {
 
   return (
     <Link key={goal._id} href={`/goals/${goal._id}`}>
-      <div className="border border-border p-6 transition-colors hover:border-text/30 group h-full flex flex-col">
+      <div className="border border-border rounded-xl p-6 transition-colors hover:border-text/30 group h-full flex flex-col">
         {/* Top row: title + health dot */}
         <div className="flex items-start justify-between gap-4 mb-3">
           <h3 className="text-lg font-bold text-text group-hover:text-accent transition-colors leading-snug">
@@ -90,7 +90,13 @@ function GoalCard({ goal }: { goal: Doc<"goals"> }) {
 export function GoalsGrid() {
   const goals = useQuery(api.goals.list, { status: "active" });
 
-  if (!goals) return <div className="text-text-muted">Loading...</div>;
+  if (!goals) return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="h-40 rounded-xl bg-surface animate-pulse" />
+      ))}
+    </div>
+  );
 
   return (
     <div className="max-w-none space-y-8">

--- a/web/src/components/sections/goals-okr.tsx
+++ b/web/src/components/sections/goals-okr.tsx
@@ -37,7 +37,7 @@ export function GoalsOkr() {
   }
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           OKR View

--- a/web/src/components/sections/goals-timeline.tsx
+++ b/web/src/components/sections/goals-timeline.tsx
@@ -78,7 +78,7 @@ export function GoalsTimeline() {
   });
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           Quarterly Timeline

--- a/web/src/components/sections/ideas-grid.tsx
+++ b/web/src/components/sections/ideas-grid.tsx
@@ -6,7 +6,8 @@ import { api } from '@/lib/convex-api';
 import type { Id } from '@/lib/convex-api';
 import { formatDate } from '@/lib/utils';
 import { IdeaForm } from '@/components/idea-form';
-import type { Doc } from '../../../../../convex/_generated/dataModel';
+import { IdeaDetailModal } from '@/components/idea-detail-modal';
+import type { Doc } from '@/lib/convex-api';
 
 // ── Types ────────────────────────────────────────────
 
@@ -91,9 +92,10 @@ function ActionabilityDropdown({ current, onSelect, onClose }: ActionabilityDrop
 interface IdeaRowProps {
   idea: Idea;
   index: number;
+  onSelect: (idea: Idea) => void;
 }
 
-function IdeaRow({ idea, index }: IdeaRowProps) {
+function IdeaRow({ idea, index, onSelect }: IdeaRowProps) {
   const [expanded, setExpanded] = useState(false);
   const [dropdownOpen, setDropdownOpen] = useState(false);
 
@@ -120,11 +122,11 @@ function IdeaRow({ idea, index }: IdeaRowProps) {
       <div
         role="button"
         tabIndex={0}
-        onClick={() => setExpanded((prev) => !prev)}
+        onClick={() => onSelect(idea)}
         onKeyDown={(e) => {
           if (e.key === 'Enter' || e.key === ' ') {
             e.preventDefault();
-            setExpanded((prev) => !prev);
+            onSelect(idea);
           }
         }}
         className="flex items-center gap-4 px-5 py-3.5 transition-colors hover:bg-surface-hover cursor-pointer group"
@@ -202,8 +204,15 @@ function IdeaRow({ idea, index }: IdeaRowProps) {
 
 export function IdeasGrid() {
   const ideas = useQuery(api.ideas.list, {});
+  const [selectedIdea, setSelectedIdea] = useState<Idea | null>(null);
 
-  if (!ideas) return <div className="text-text-muted">Loading...</div>;
+  if (!ideas) return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="h-40 rounded-xl bg-surface animate-pulse" />
+      ))}
+    </div>
+  );
 
   // Sort by creation time descending (newest first)
   const sorted = [...ideas].sort((a, b) => b._creationTime - a._creationTime);
@@ -228,10 +237,34 @@ export function IdeasGrid() {
 
       {/* Ideas Table */}
       {sorted.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20">
-          <p className="text-base font-medium text-text">No ideas yet</p>
-          <p className="text-sm text-text-muted mt-1">
-            Capture one above to get started.
+        <div className="space-y-4">
+          <div className="border border-dashed border-border/50 rounded-xl overflow-hidden">
+            {[
+              { content: 'What if we could automate the weekly review...', level: 'High' },
+              { content: 'A better way to track daily wins and progress', level: 'Medium' },
+              { content: 'Explore integrating with calendar for reminders', level: 'Low' },
+            ].map((ghost, idx) => (
+              <div
+                key={idx}
+                className="flex items-center gap-4 px-5 py-3.5 opacity-40 border-b border-border/30 last:border-b-0"
+              >
+                <span className="text-xs font-mono text-text-muted w-8 shrink-0">
+                  [{String(idx + 1).padStart(2, '0')}]
+                </span>
+                <span className="flex-1 text-sm text-text-muted italic truncate min-w-0">
+                  {ghost.content}
+                </span>
+                <span className="text-xs font-medium px-2 py-0.5 rounded border border-border/50 text-text-muted shrink-0">
+                  {ghost.level}
+                </span>
+                <span className="text-xs text-text-muted font-mono shrink-0 w-16 text-right">
+                  Today
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-sm text-text-muted/70">
+            Capture your first idea
           </p>
         </div>
       ) : (
@@ -247,9 +280,22 @@ export function IdeasGrid() {
 
           {/* Rows */}
           {sorted.map((idea, idx) => (
-            <IdeaRow key={idea._id} idea={idea} index={idx + 1} />
+            <IdeaRow key={idea._id} idea={idea} index={idx + 1} onSelect={setSelectedIdea} />
           ))}
         </div>
+      )}
+
+      {/* Detail Modal */}
+      {selectedIdea && (
+        <IdeaDetailModal
+          idea={selectedIdea}
+          allIdeas={ideas ?? []}
+          onClose={() => setSelectedIdea(null)}
+          onSelectIdea={(id) => {
+            const found = ideas?.find((i) => i._id === id);
+            if (found) setSelectedIdea(found);
+          }}
+        />
       )}
     </div>
   );

--- a/web/src/components/sections/ideas-pipeline.tsx
+++ b/web/src/components/sections/ideas-pipeline.tsx
@@ -33,7 +33,7 @@ export function IdeasPipeline() {
   const top5 = sorted.slice(0, 5);
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Ideas Pipeline

--- a/web/src/components/sections/ideas-priority.tsx
+++ b/web/src/components/sections/ideas-priority.tsx
@@ -31,7 +31,7 @@ export function IdeasPriority() {
   });
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           Ideas by Priority

--- a/web/src/components/sections/identity-statement.tsx
+++ b/web/src/components/sections/identity-statement.tsx
@@ -37,7 +37,7 @@ export function IdentityStatement() {
   }
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       {/* Header */}
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">

--- a/web/src/components/sections/journal-editor.tsx
+++ b/web/src/components/sections/journal-editor.tsx
@@ -27,7 +27,7 @@ export function JournalEditor() {
   }
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           Journal -- {formatFullDate(todayStr)}

--- a/web/src/components/sections/journal-list.tsx
+++ b/web/src/components/sections/journal-list.tsx
@@ -24,7 +24,7 @@ export function JournalList() {
   }
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           Journal Entries

--- a/web/src/components/sections/journal-timeline.tsx
+++ b/web/src/components/sections/journal-timeline.tsx
@@ -3,7 +3,7 @@
 import { useQuery } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { JournalForm } from '@/components/journal-form';
-import type { Doc } from '../../../../../convex/_generated/dataModel';
+import type { Doc } from '@/lib/convex-api';
 
 type JournalEntry = Doc<'journals'>;
 
@@ -147,7 +147,13 @@ function EntryCard({ entry }: { entry: JournalEntry }) {
 export function JournalTimeline() {
   const entries = useQuery(api.journals.list, {});
 
-  if (!entries) return <div className="text-text-muted">Loading...</div>;
+  if (!entries) return (
+    <div className="space-y-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="h-16 rounded-xl bg-surface animate-pulse" />
+      ))}
+    </div>
+  );
 
   return (
     <div className="max-w-none space-y-8">
@@ -162,10 +168,47 @@ export function JournalTimeline() {
 
       {/* Entries */}
       {entries.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20">
-          <p className="text-base font-medium text-text">No entries yet</p>
-          <p className="mt-1 text-sm text-text-muted">
-            Start writing to track your days.
+        <div className="space-y-4">
+          {/* Ghost journal entry */}
+          <div className="border border-dashed border-border/50 rounded-xl p-6 opacity-40">
+            <h3 className="text-lg font-semibold text-text-muted mb-5">Today</h3>
+            <div>
+              <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                Priorities
+              </span>
+              <div className="mt-2.5 space-y-2">
+                <div className="flex items-start gap-3 text-sm">
+                  <span className="mt-1 shrink-0">
+                    <svg width="10" height="10" viewBox="0 0 10 10">
+                      <circle cx="5" cy="5" r="4" fill="currentColor" className="text-text-muted" />
+                    </svg>
+                  </span>
+                  <span className="shrink-0 text-xs font-bold uppercase tracking-wide text-text-muted w-7">MIT</span>
+                  <span className="text-text-muted italic">Your most important task</span>
+                </div>
+                <div className="flex items-start gap-3 text-sm">
+                  <span className="mt-1 shrink-0">
+                    <svg width="10" height="10" viewBox="0 0 10 10">
+                      <circle cx="5" cy="5" r="3.5" fill="none" stroke="currentColor" strokeWidth="1" className="text-text-muted" />
+                    </svg>
+                  </span>
+                  <span className="shrink-0 text-xs font-bold uppercase tracking-wide text-text-muted w-7">P1</span>
+                  <span className="text-text-muted italic">Second priority for the day</span>
+                </div>
+              </div>
+            </div>
+            <div className="border-t border-border/50 my-5" />
+            <div>
+              <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
+                Journal
+              </span>
+              <div className="mt-2.5 text-sm text-text-muted italic leading-relaxed">
+                How was your day? What did you learn?
+              </div>
+            </div>
+          </div>
+          <p className="text-center text-sm text-text-muted/70">
+            Start your first journal entry
           </p>
         </div>
       ) : (

--- a/web/src/components/sections/journal-today.tsx
+++ b/web/src/components/sections/journal-today.tsx
@@ -28,7 +28,7 @@ export function JournalToday() {
   }
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Journal

--- a/web/src/components/sections/overdue-alert.tsx
+++ b/web/src/components/sections/overdue-alert.tsx
@@ -16,7 +16,7 @@ export function OverdueAlert() {
   }
 
   return (
-    <div className="border border-danger/40 px-6 py-4 flex items-center justify-between">
+    <div className="border border-danger/40 rounded-xl px-6 py-4 flex items-center justify-between">
       <div className="flex-1 min-w-0">
         <p className="text-sm font-medium text-danger">
           {overdueTasks.length} overdue task{overdueTasks.length !== 1 ? 's' : ''}

--- a/web/src/components/sections/priorities-checklist.tsx
+++ b/web/src/components/sections/priorities-checklist.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState, useRef, useEffect, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import type { Id } from '@/lib/convex-api';
@@ -47,6 +48,177 @@ const PRIORITIES: PriorityConfig[] = [
   },
 ];
 
+// ── Date helpers ─────────────────────────────────────────
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+function tomorrowISO(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+function sevenDaysISO(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 7);
+  return d.toISOString().slice(0, 10);
+}
+
+// ── Grouped task type ────────────────────────────────────
+
+interface TaskItem {
+  _id: Id<'tasks'>;
+  title: string;
+  dueDate?: string;
+}
+
+interface TaskGroup {
+  key: string;
+  label: string;
+  headerClass?: string;
+  tasks: TaskItem[];
+}
+
+function groupTasks(tasks: TaskItem[]): TaskGroup[] {
+  const today = todayISO();
+  const tomorrow = tomorrowISO();
+  const weekEnd = sevenDaysISO();
+
+  const groups: Record<string, TaskItem[]> = {
+    overdue: [],
+    today: [],
+    tomorrow: [],
+    thisWeek: [],
+    later: [],
+    noDate: [],
+  };
+
+  for (const task of tasks) {
+    const due = task.dueDate;
+    if (!due) {
+      groups.noDate.push(task);
+    } else if (due < today) {
+      groups.overdue.push(task);
+    } else if (due === today) {
+      groups.today.push(task);
+    } else if (due === tomorrow) {
+      groups.tomorrow.push(task);
+    } else if (due <= weekEnd) {
+      groups.thisWeek.push(task);
+    } else {
+      groups.later.push(task);
+    }
+  }
+
+  const result: TaskGroup[] = [];
+
+  if (groups.overdue.length > 0) {
+    result.push({ key: 'overdue', label: 'Overdue', headerClass: 'text-danger/60', tasks: groups.overdue });
+  }
+  if (groups.today.length > 0) {
+    result.push({ key: 'today', label: 'Today', tasks: groups.today });
+  }
+  if (groups.tomorrow.length > 0) {
+    result.push({ key: 'tomorrow', label: 'Tomorrow', tasks: groups.tomorrow });
+  }
+  if (groups.thisWeek.length > 0) {
+    result.push({ key: 'thisWeek', label: 'This Week', tasks: groups.thisWeek });
+  }
+  if (groups.later.length > 0) {
+    result.push({ key: 'later', label: 'Later', tasks: groups.later });
+  }
+  if (groups.noDate.length > 0) {
+    result.push({ key: 'noDate', label: 'No date', tasks: groups.noDate });
+  }
+
+  return result;
+}
+
+function formatDueDate(dueDate?: string): string | null {
+  if (!dueDate) return null;
+  const today = todayISO();
+  const tomorrow = tomorrowISO();
+  if (dueDate === today) return 'Today';
+  if (dueDate === tomorrow) return 'Tomorrow';
+  // Show short date like "Mar 28"
+  const d = new Date(dueDate + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+}
+
+// ── TaskPickerDropdown ──────────────────────────────────
+
+function TaskPickerDropdown({
+  tasks,
+  onSelect,
+  onClose,
+}: {
+  tasks: TaskItem[];
+  onSelect: (taskId: Id<'tasks'>) => void;
+  onClose: () => void;
+}) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  const groups = useMemo(() => groupTasks(tasks), [tasks]);
+
+  if (tasks.length === 0) {
+    return (
+      <div
+        ref={ref}
+        className="absolute left-0 right-0 top-full mt-1 z-30 rounded-xl border border-border bg-surface shadow-lg p-3"
+      >
+        <p className="text-xs text-text-muted">No tasks available</p>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={ref}
+      className="absolute left-0 right-0 top-full mt-1 z-30 rounded-xl border border-border bg-surface shadow-lg max-h-72 overflow-y-auto"
+    >
+      {groups.map((group) => (
+        <div key={group.key}>
+          <div
+            className={cn(
+              'text-[10px] font-semibold uppercase tracking-widest px-3 pt-3 pb-1',
+              group.headerClass ?? 'text-text-muted/50',
+            )}
+          >
+            {group.label}
+          </div>
+          {group.tasks.map((task) => {
+            const dueDateLabel = formatDueDate(task.dueDate);
+            return (
+              <button
+                key={task._id}
+                onClick={() => onSelect(task._id)}
+                className="w-full text-left px-3 py-2 text-sm text-text hover:bg-surface-hover transition-colors flex items-center justify-between gap-2"
+              >
+                <span className="truncate">{task.title}</span>
+                {dueDateLabel && (
+                  <span className="text-[10px] text-text-muted/50 shrink-0">
+                    {dueDateLabel}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 // ── PriorityRow sub-component ────────────────────────────
 // Each row calls useQuery independently so conditional "skip" works.
 
@@ -55,19 +227,29 @@ function PriorityRow({
   taskId,
   done,
   onToggle,
+  allTasks,
+  assignedIds,
+  onAssign,
 }: {
   config: PriorityConfig;
   taskId: Id<'tasks'> | undefined;
   done: boolean;
   onToggle: () => void;
+  allTasks: TaskItem[] | undefined;
+  assignedIds: Set<string>;
+  onAssign: (taskId: Id<'tasks'>) => void;
 }) {
   const task = useQuery(api.tasks.get, taskId ? { id: taskId } : 'skip');
+  const [pickerOpen, setPickerOpen] = useState(false);
 
   const title = task?.title ?? (taskId ? 'Loading...' : 'Not assigned');
   const isLoading = taskId !== undefined && task === undefined;
 
+  // Filter out tasks already assigned to other priority slots
+  const availableTasks = allTasks?.filter((t) => !assignedIds.has(t._id)) ?? [];
+
   return (
-    <div className="flex items-center gap-4 py-3 group">
+    <div className="relative flex items-center gap-4 py-3 group">
       {/* Checkbox */}
       <button
         onClick={onToggle}
@@ -107,23 +289,52 @@ function PriorityRow({
         {config.label}
       </span>
 
-      {/* Task title */}
-      <span
+      {/* Task title - clickable to reassign */}
+      <button
+        onClick={() => setPickerOpen((v) => !v)}
         className={cn(
-          'flex-1 text-sm transition-colors truncate',
+          'flex-1 text-left text-sm transition-colors truncate',
           isLoading && 'animate-pulse text-text-muted',
-          done ? 'line-through text-text-muted' : 'text-text',
-          !taskId && 'text-text-muted italic',
+          taskId
+            ? (done ? 'line-through text-text-muted' : 'text-text hover:text-accent')
+            : 'text-text-muted italic',
         )}
       >
         {title}
-      </span>
+      </button>
+
+      {/* Change indicator */}
+      {taskId && !done && (
+        <button
+          onClick={() => setPickerOpen((v) => !v)}
+          className="opacity-0 group-hover:opacity-100 flex h-5 w-5 items-center justify-center rounded-md text-text-muted hover:text-accent hover:bg-surface-hover transition-all"
+          aria-label={`Change ${config.label} task`}
+          title="Change task"
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+          </svg>
+        </button>
+      )}
 
       {/* Done indicator */}
       {done && (
-        <span className="text-xs font-mono text-success uppercase tracking-wide">
+        <span className="text-xs text-success font-medium uppercase tracking-wide">
           Done
         </span>
+      )}
+
+      {/* Task picker dropdown */}
+      {pickerOpen && (
+        <TaskPickerDropdown
+          tasks={availableTasks}
+          onSelect={(id) => {
+            onAssign(id);
+            setPickerOpen(false);
+          }}
+          onClose={() => setPickerOpen(false)}
+        />
       )}
     </div>
   );
@@ -136,12 +347,15 @@ export function PrioritiesChecklist() {
   const dayPlan = useQuery(api.dayPlans.getByDate, { date });
   const upsert = useMutation(api.dayPlans.upsert);
 
-  // Also fetch today's tasks for the "more tasks" count
+  // Fetch today's tasks for the "more tasks" count
   const todayTasks = useQuery(api.tasks.list, { status: 'todo', due: 'today' });
+
+  // Fetch ALL todo tasks for the task picker dropdown
+  const allTasks = useQuery(api.tasks.list, { status: 'todo' });
 
   if (dayPlan === undefined) {
     return (
-      <div className="border border-border">
+      <div className="rounded-xl border border-border">
         <div className="px-6 py-4 border-b border-border">
           <div className="animate-pulse h-4 w-32 bg-surface rounded" />
         </div>
@@ -158,22 +372,28 @@ export function PrioritiesChecklist() {
     void upsert({ date, [field]: !currentValue });
   };
 
+  const handleAssign = (taskIdField: 'mitTaskId' | 'p1TaskId' | 'p2TaskId', taskId: Id<'tasks'>) => {
+    void upsert({ date, [taskIdField]: taskId });
+  };
+
   const completedCount = [
     dayPlan?.mitDone ?? false,
     dayPlan?.p1Done ?? false,
     dayPlan?.p2Done ?? false,
   ].filter(Boolean).length;
 
-  // Count extra tasks beyond the 3 priorities
-  const priorityIds = new Set(
-    [dayPlan?.mitTaskId, dayPlan?.p1TaskId, dayPlan?.p2TaskId].filter(Boolean),
+  // Collect IDs already assigned to priority slots
+  const assignedIds = new Set(
+    [dayPlan?.mitTaskId, dayPlan?.p1TaskId, dayPlan?.p2TaskId].filter(Boolean) as string[],
   );
+
+  // Count extra tasks beyond the 3 priorities (today's tasks only)
   const extraTaskCount = todayTasks
-    ? todayTasks.filter((t) => !priorityIds.has(t._id)).length
+    ? todayTasks.filter((t) => !assignedIds.has(t._id)).length
     : 0;
 
   return (
-    <div className="border border-border">
+    <div className="rounded-xl border border-border">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Priorities
@@ -194,14 +414,34 @@ export function PrioritiesChecklist() {
               onToggle={() =>
                 handleToggle(config.doneField, dayPlan[config.doneField])
               }
+              allTasks={allTasks}
+              assignedIds={assignedIds}
+              onAssign={(taskId) => handleAssign(config.taskIdField, taskId)}
             />
           ))}
         </div>
       ) : (
-        <div className="flex flex-col items-center justify-center py-12 px-6 text-center">
-          <p className="text-sm text-text-muted">No plan for this day</p>
-          <p className="text-xs text-text-muted/60 mt-1">
-            Create a day plan to set your priorities
+        <div className="px-6 py-2">
+          {/* Ghost priority rows */}
+          <div className="divide-y divide-border/30">
+            {[
+              { label: 'MIT', colorClass: 'text-accent/40', placeholder: 'Set your most important task' },
+              { label: 'P1', colorClass: 'text-purple-500/40', placeholder: 'Set your second priority' },
+              { label: 'P2', colorClass: 'text-indigo-500/40', placeholder: 'Set your third priority' },
+            ].map((item) => (
+              <div key={item.label} className="flex items-center gap-4 py-3 opacity-40">
+                <div className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full border-2 border-dashed border-text-muted/40" />
+                <span className={cn('text-xs font-bold uppercase tracking-widest shrink-0 w-8', item.colorClass)}>
+                  {item.label}
+                </span>
+                <span className="flex-1 text-sm text-text-muted italic truncate">
+                  {item.placeholder}
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-xs text-text-muted/70 mt-4 mb-2">
+            Set your priorities to start your day
           </p>
         </div>
       )}

--- a/web/src/components/sections/projects-grid.tsx
+++ b/web/src/components/sections/projects-grid.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { useQuery } from 'convex/react';
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
+import type { Id } from '@/lib/convex-api';
 import { formatDate } from '@/lib/utils';
-import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { ProjectDetailModal } from '@/components/project-detail-modal';
 
 const statusColor = (status: string) => {
   switch (status) {
@@ -31,10 +34,105 @@ const statusLabel = (status: string) => {
   }
 };
 
+function ProjectCreateModal({ onClose }: { onClose: () => void }) {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [loading, setLoading] = useState(false);
+  const createProject = useMutation(api.projects.create);
+
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [onClose]);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!title.trim()) return;
+    setLoading(true);
+    try {
+      const args: { title: string; description?: string } = { title: title.trim() };
+      if (description.trim()) args.description = description.trim();
+      await createProject(args);
+      onClose();
+    } catch (err) {
+      console.error('Failed to create project:', err);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+      onClick={onClose}
+    >
+      <div
+        className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg p-6 space-y-4 animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text">New Project</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-text-muted hover:text-text transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="text"
+            placeholder="Project title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            autoFocus
+            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
+          <textarea
+            placeholder="Description (optional)"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={3}
+            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
+          />
+          <div className="flex gap-2">
+            <Button type="submit" disabled={loading || !title.trim()}>
+              {loading ? 'Creating...' : 'Create Project'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={onClose}>
+              Cancel
+            </Button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 export function ProjectsGrid() {
   const projects = useQuery(api.projects.list, { status: "active" });
+  const [showCreate, setShowCreate] = useState(false);
+  const [selectedProjectId, setSelectedProjectId] = useState<Id<'projects'> | null>(null);
 
-  if (!projects) return <div className="text-text-muted">Loading...</div>;
+  if (!projects) return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="h-40 rounded-xl bg-surface animate-pulse" />
+      ))}
+    </div>
+  );
 
   return (
     <div className="max-w-none space-y-8">
@@ -43,18 +141,58 @@ export function ProjectsGrid() {
         <h1 className="text-3xl font-bold tracking-tight text-text">
           Projects <span className="text-text-muted font-normal">[ {projects.length} ]</span>
         </h1>
-        <Link
-          href="/projects/new"
-          className="bg-white text-black px-5 py-2.5 text-sm font-medium uppercase tracking-wide hover:bg-white/90 transition-colors"
+        <button
+          onClick={() => setShowCreate(true)}
+          className="bg-white text-black px-5 py-2.5 text-sm font-medium uppercase tracking-wide hover:bg-white/90 transition-colors rounded-xl"
         >
           New Project
-        </Link>
+        </button>
       </div>
 
+      {showCreate && <ProjectCreateModal onClose={() => setShowCreate(false)} />}
+      {selectedProjectId && (
+        <ProjectDetailModal
+          projectId={selectedProjectId}
+          onClose={() => setSelectedProjectId(null)}
+        />
+      )}
+
       {projects.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20">
-          <p className="text-base font-medium text-text">No active projects</p>
-          <p className="text-sm text-text-muted mt-1">Create one to get started.</p>
+        <div className="space-y-6">
+          <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {[
+              { title: 'Product Launch', desc: 'Plan and execute your next big release' },
+              { title: 'Website Redesign', desc: 'Refresh the look and feel of your site' },
+              { title: 'Growth Strategy', desc: 'Define key initiatives for this quarter' },
+            ].map((ghost, idx) => (
+              <div
+                key={ghost.title}
+                className="border border-dashed border-border/50 p-6 opacity-40 h-full flex flex-col rounded-xl"
+              >
+                <div className="flex items-center justify-between mb-4">
+                  <span className="text-xs font-mono text-text-muted">
+                    [{String(idx + 1).padStart(2, '0')}]
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <span className="h-2 w-2 rounded-full bg-text-muted" />
+                    <span className="text-xs text-text-muted">Active</span>
+                  </div>
+                </div>
+                <h3 className="text-base font-bold text-text-muted leading-snug mb-2">
+                  {ghost.title}
+                </h3>
+                <p className="text-sm text-text-muted/70 line-clamp-2 leading-relaxed mb-4 italic">
+                  {ghost.desc}
+                </p>
+                <div className="mt-auto pt-4 border-t border-border/30">
+                  <span className="text-xs font-mono text-text-muted">Today</span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-sm text-text-muted/70">
+            Create your first project
+          </p>
         </div>
       ) : (
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
@@ -63,8 +201,11 @@ export function ProjectsGrid() {
               ? new Date(project._creationTime).toISOString().slice(0, 10)
               : null;
             return (
-              <Link key={project._id} href={`/projects/${project._id}`}>
-                <div className="border border-border p-6 transition-colors hover:border-text/30 group h-full flex flex-col">
+              <div
+                key={project._id}
+                className="border border-border rounded-xl p-6 transition-colors hover:border-text/30 group h-full flex flex-col cursor-pointer"
+                onClick={() => setSelectedProjectId(project._id)}
+              >
                   {/* Index + Status */}
                   <div className="flex items-center justify-between mb-4">
                     <span className="text-xs font-mono text-text-muted">
@@ -94,8 +235,7 @@ export function ProjectsGrid() {
                       {formatDate(createdDate)}
                     </span>
                   </div>
-                </div>
-              </Link>
+              </div>
             );
           })}
         </div>

--- a/web/src/components/sections/quarterly-goals.tsx
+++ b/web/src/components/sections/quarterly-goals.tsx
@@ -4,9 +4,10 @@ import { useState, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import type { Id } from '@/lib/convex-api';
-import type { Doc } from '../../../../../convex/_generated/dataModel';
+import type { Doc } from '@/lib/convex-api';
 import { cn } from '@/lib/utils';
 import { GoalForm } from '@/components/goal-form';
+import { GoalDetailModal } from '@/components/goal-detail-modal';
 
 // ── Helpers ────────────────────────────────────────────
 
@@ -32,7 +33,7 @@ const healthDot: Record<string, string> = {
 
 // ── GoalRow ──────────────────────────────────────────
 
-function GoalRow({ goal }: { goal: Doc<'goals'> }) {
+function GoalRow({ goal, onSelect }: { goal: Doc<'goals'>; onSelect: (goalId: Id<'goals'>) => void }) {
   const [expanded, setExpanded] = useState(false);
   const health = useQuery(api.goals.health, { id: goal._id });
   const goalDetail = useQuery(api.goals.get, expanded ? { id: goal._id } : 'skip');
@@ -83,9 +84,9 @@ function GoalRow({ goal }: { goal: Doc<'goals'> }) {
           )}
         </button>
 
-        {/* Title + expand toggle */}
+        {/* Title + open detail */}
         <button
-          onClick={() => setExpanded(!expanded)}
+          onClick={() => onSelect(goal._id)}
           className="flex-1 flex items-center gap-3 text-left min-w-0"
         >
           <span className="text-xs text-text-muted shrink-0">
@@ -177,10 +178,12 @@ function QuarterSection({
   quarter,
   goals,
   isCurrent,
+  onSelectGoal,
 }: {
   quarter: string;
   goals: Doc<'goals'>[];
   isCurrent: boolean;
+  onSelectGoal: (goalId: Id<'goals'>) => void;
 }) {
   const activeCount = goals.filter((g) => g.status === 'active').length;
   const completedCount = goals.filter((g) => g.status === 'completed').length;
@@ -217,7 +220,7 @@ function QuarterSection({
 
       {/* Goal rows */}
       {goals.map((goal) => (
-        <GoalRow key={goal._id} goal={goal} />
+        <GoalRow key={goal._id} goal={goal} onSelect={onSelectGoal} />
       ))}
     </div>
   );
@@ -228,6 +231,7 @@ function QuarterSection({
 export function QuarterlyGoals() {
   const allGoals = useQuery(api.goals.list, {});
   const currentQuarter = useMemo(() => getCurrentQuarter(), []);
+  const [selectedGoalId, setSelectedGoalId] = useState<Id<'goals'> | null>(null);
 
   const grouped = useMemo(() => {
     if (!allGoals) return null;
@@ -271,9 +275,61 @@ export function QuarterlyGoals() {
 
       {/* Quarters */}
       {grouped && grouped.sorted.length === 0 && grouped.unassigned.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20">
-          <p className="text-base font-medium text-text">No goals yet</p>
-          <p className="text-sm text-text-muted mt-1">Create a goal to get started.</p>
+        <div className="space-y-4">
+          {/* Ghost quarter section */}
+          <div className="border border-dashed border-border/50 rounded-xl overflow-hidden">
+            {/* Quarter header */}
+            <div className="flex items-baseline justify-between px-4 py-3 border-b border-border/30 bg-accent/5 opacity-60">
+              <div className="flex items-center gap-3">
+                <h3 className="text-sm font-bold text-text-muted uppercase tracking-wide font-mono">
+                  {currentQuarter}
+                </h3>
+                <span className="text-[10px] font-bold uppercase tracking-wider text-accent/60">
+                  Current
+                </span>
+              </div>
+              <span className="text-xs text-text-muted">0/3 done</span>
+            </div>
+
+            {/* Ghost goal rows */}
+            {[
+              { title: 'Launch product beta', tasks: 5 },
+              { title: 'Grow revenue to $10k MRR', tasks: 3 },
+              { title: 'Hire 2 team members', tasks: 2 },
+            ].map((ghost, idx) => (
+              <div
+                key={idx}
+                className="flex items-center gap-3 px-4 py-3 opacity-40 border-b border-border/30 last:border-b-0"
+              >
+                {/* Ghost checkbox */}
+                <div className="flex h-5 w-5 shrink-0 items-center justify-center rounded border border-dashed border-border" />
+
+                {/* Title */}
+                <div className="flex-1 flex items-center gap-3 min-w-0">
+                  <span className="text-xs text-text-muted shrink-0">{'\u25B8'}</span>
+                  <span className="text-sm font-medium text-text-muted italic truncate">
+                    {ghost.title}
+                  </span>
+                </div>
+
+                {/* Status badge */}
+                <span className="shrink-0 rounded px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider bg-accent/10 text-accent/50">
+                  Active
+                </span>
+
+                {/* Health dot */}
+                <span className="h-2 w-2 rounded-full shrink-0 bg-text-muted/50" />
+
+                {/* Task count */}
+                <span className="text-xs font-mono text-text-muted shrink-0 w-14 text-right">
+                  {ghost.tasks} tasks
+                </span>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-sm text-text-muted/70">
+            Set your first quarterly goal
+          </p>
         </div>
       ) : grouped ? (
         <div className="space-y-6">
@@ -283,6 +339,7 @@ export function QuarterlyGoals() {
               quarter={quarter}
               goals={goals}
               isCurrent={quarter === currentQuarter}
+              onSelectGoal={setSelectedGoalId}
             />
           ))}
 
@@ -291,10 +348,19 @@ export function QuarterlyGoals() {
               quarter="No Quarter"
               goals={grouped.unassigned}
               isCurrent={false}
+              onSelectGoal={setSelectedGoalId}
             />
           )}
         </div>
       ) : null}
+
+      {/* Detail Modal */}
+      {selectedGoalId && (
+        <GoalDetailModal
+          goalId={selectedGoalId}
+          onClose={() => setSelectedGoalId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/sections/quarterly-review-form.tsx
+++ b/web/src/components/sections/quarterly-review-form.tsx
@@ -43,9 +43,15 @@ function formatDateLong(d: Date): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
+// ── Props ────────────────────────────────────────────
+
+interface QuarterlyReviewFormProps {
+  onSaved?: () => void;
+}
+
 // ── Main component ───────────────────────────────────
 
-export function QuarterlyReviewForm() {
+export function QuarterlyReviewForm({ onSaved }: QuarterlyReviewFormProps = {}) {
   const quarter = useMemo(() => getCurrentQuarterRange(), []);
   const quarterStartStr = toDateStr(quarter.start);
   const quarterEndStr = toDateStr(quarter.end);
@@ -136,6 +142,7 @@ export function QuarterlyReviewForm() {
         score: scoreNum,
       });
       setSaved(true);
+      onSaved?.();
     } finally {
       setSaving(false);
     }
@@ -143,7 +150,7 @@ export function QuarterlyReviewForm() {
 
   if (saved) {
     return (
-      <div className="border border-border p-8 text-center">
+      <div className="border border-border rounded-xl p-8 text-center">
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mx-auto mb-3 text-success">
           <polyline points="20 6 9 17 4 12" />
         </svg>
@@ -158,7 +165,7 @@ export function QuarterlyReviewForm() {
   const isLoading = allReviews === undefined || allGoals === undefined;
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl">
       {/* Header */}
       <div className="px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
@@ -188,7 +195,7 @@ export function QuarterlyReviewForm() {
               onChange={(e) => setSummary(e.target.value)}
               placeholder="How would you summarize this quarter?"
               rows={4}
-              className="w-full bg-surface border border-border px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
+              className="w-full bg-surface border border-border rounded-lg px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
             />
           </div>
 
@@ -219,7 +226,7 @@ export function QuarterlyReviewForm() {
               onChange={(e) => setAdditionalAchievements(e.target.value)}
               placeholder="Add more achievements (one per line)..."
               rows={3}
-              className="w-full bg-surface border border-border px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
+              className="w-full bg-surface border border-border rounded-lg px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
             />
           </div>
 
@@ -269,7 +276,7 @@ export function QuarterlyReviewForm() {
               onChange={(e) => setWhatDidntWork(e.target.value)}
               placeholder="What would you do differently?"
               rows={3}
-              className="w-full bg-surface border border-border px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
+              className="w-full bg-surface border border-border rounded-lg px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
             />
           </div>
 
@@ -283,7 +290,7 @@ export function QuarterlyReviewForm() {
               onChange={(e) => setNextQuarterGoals(e.target.value)}
               placeholder="What do you want to achieve next quarter? (one per line)"
               rows={4}
-              className="w-full bg-surface border border-border px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
+              className="w-full bg-surface border border-border rounded-lg px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
             />
           </div>
 
@@ -299,7 +306,7 @@ export function QuarterlyReviewForm() {
               value={score}
               onChange={(e) => setScore(e.target.value)}
               placeholder="Rate this quarter"
-              className="w-24 bg-surface border border-border px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
+              className="w-24 bg-surface border border-border rounded-lg px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
             />
           </div>
 
@@ -308,7 +315,7 @@ export function QuarterlyReviewForm() {
             <button
               onClick={handleSave}
               disabled={saving || !score || parseInt(score, 10) < 1 || parseInt(score, 10) > 10}
-              className="px-6 py-2.5 text-sm font-bold uppercase tracking-wide bg-accent text-bg hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              className="px-6 py-2.5 text-sm font-bold uppercase tracking-wide bg-accent text-bg rounded-lg hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {saving ? 'Saving...' : 'Save Quarterly Review'}
             </button>

--- a/web/src/components/sections/quotes.tsx
+++ b/web/src/components/sections/quotes.tsx
@@ -54,13 +54,13 @@ export function Quotes() {
   const quote = QUOTES[index];
 
   return (
-    <div className="border border-border">
+    <div className="mt-2 border border-border rounded-xl">
       <div className="px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Daily Quote
         </h2>
       </div>
-      <div className="px-6 py-8 flex flex-col items-center text-center">
+      <div className="px-6 py-10 flex flex-col items-center text-center">
         <p className="text-sm italic text-text leading-relaxed max-w-md">
           &ldquo;{quote.text}&rdquo;
         </p>

--- a/web/src/components/sections/reminders-upcoming.tsx
+++ b/web/src/components/sections/reminders-upcoming.tsx
@@ -60,7 +60,7 @@ export function RemindersUpcoming() {
 
   if (allReminders === undefined) {
     return (
-      <div className="border border-border">
+      <div className="border border-border rounded-xl overflow-hidden">
         <div className="px-6 py-4 border-b border-border">
           <div className="animate-pulse h-4 w-40 bg-surface rounded" />
         </div>
@@ -82,7 +82,7 @@ export function RemindersUpcoming() {
   };
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Upcoming Reminders

--- a/web/src/components/sections/resources-grid.tsx
+++ b/web/src/components/sections/resources-grid.tsx
@@ -4,7 +4,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import type { Id } from '@/lib/convex-api';
-import type { Doc } from '../../../../../convex/_generated/dataModel';
+import type { Doc } from '@/lib/convex-api';
 
 // ── Types ────────────────────────────────────────────
 
@@ -317,7 +317,7 @@ function AddResourceForm({ onClose }: AddFormProps) {
   );
 
   return (
-    <form onSubmit={handleSubmit} className="border border-border p-5 space-y-4">
+    <form onSubmit={handleSubmit} className="border border-border rounded-xl p-5 space-y-4">
       <div className="flex items-center justify-between mb-2">
         <p className="text-xs font-bold text-text-muted uppercase tracking-widest">
           Add Resource
@@ -740,7 +740,13 @@ export function ResourcesGrid() {
   }, [selectedId, resources]);
 
   if (!resources) {
-    return <div className="text-text-muted">Loading...</div>;
+    return (
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-40 rounded-xl bg-surface animate-pulse" />
+        ))}
+      </div>
+    );
   }
 
   // Detail view
@@ -846,7 +852,7 @@ export function ResourcesGrid() {
           </p>
         </div>
       ) : (
-        <div className="border border-border">
+        <div className="border border-border rounded-xl overflow-hidden">
           {/* Table header */}
           <div className="flex items-center gap-4 px-5 py-2.5 border-b border-border bg-surface">
             <span className="w-6 shrink-0" />

--- a/web/src/components/sections/reviews-schedule.tsx
+++ b/web/src/components/sections/reviews-schedule.tsx
@@ -3,8 +3,20 @@
 import { useState } from 'react';
 import { useQuery } from 'convex/react';
 import { api } from '@/lib/convex-api';
+import { WeeklyReviewForm } from './weekly-review-form';
+import { QuarterlyReviewForm } from './quarterly-review-form';
 
 // ── Date helpers ─────────────────────────────────────
+
+function getLastSunday(): Date {
+  const now = new Date();
+  const day = now.getDay(); // 0 = Sunday
+  const diff = day === 0 ? 0 : day;
+  const last = new Date(now);
+  last.setDate(now.getDate() - diff);
+  last.setHours(0, 0, 0, 0);
+  return last;
+}
 
 function getNextSunday(): Date {
   const now = new Date();
@@ -56,6 +68,13 @@ function getQuarterStart(): Date {
   return new Date(year, startMonth, 1);
 }
 
+function getPreviousQuarterEnd(): Date {
+  const qStart = getQuarterStart();
+  const prev = new Date(qStart);
+  prev.setDate(prev.getDate() - 1);
+  return prev;
+}
+
 function formatDateShort(date: Date): string {
   return date.toLocaleDateString('en-US', { weekday: 'long', month: 'short', day: 'numeric' });
 }
@@ -75,67 +94,109 @@ function toDateStr(d: Date): string {
   return `${y}-${m}-${day}`;
 }
 
+function daysBetween(a: Date, b: Date): number {
+  const msPerDay = 1000 * 60 * 60 * 24;
+  return Math.floor((b.getTime() - a.getTime()) / msPerDay);
+}
+
 // ── Types ────────────────────────────────────────────
 
 type ReviewFormType = 'weekly' | 'quarterly' | null;
 
-interface ReviewsScheduleProps {
-  onStartReview?: (type: ReviewFormType) => void;
-}
-
 // ── Component ────────────────────────────────────────
 
-export function ReviewsSchedule({ onStartReview }: ReviewsScheduleProps = {}) {
+export function ReviewsSchedule() {
   const reviews = useQuery(api.reviews.list, {});
   const [activeForm, setActiveForm] = useState<ReviewFormType>(null);
 
   if (!reviews) {
     return (
-      <div className="border border-border p-6">
+      <div className="border border-border rounded-xl p-6">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide mb-4">
           Review Schedule
         </h2>
         <div className="animate-pulse space-y-3">
-          <div className="h-10 bg-surface rounded" />
-          <div className="h-10 bg-surface rounded" />
+          <div className="h-10 bg-surface rounded-lg" />
+          <div className="h-10 bg-surface rounded-lg" />
         </div>
       </div>
     );
   }
+
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
 
   const nextSunday = getNextSunday();
   const weekStart = getWeekStartForSunday(nextSunday);
   const quarterEnd = getQuarterEnd();
   const quarterStart = getQuarterStart();
 
-  // Check if we already have a weekly review covering this coming period
+  // -- Current period checks --
   const weekStartStr = toDateStr(weekStart);
   const weekEndStr = toDateStr(nextSunday);
   const hasCurrentWeeklyReview = reviews.some(
     (r) => r.reviewType === 'weekly' && r.periodStart === weekStartStr && r.periodEnd === weekEndStr,
   );
 
-  // Check if we already have a quarterly review for this quarter
   const qStartStr = toDateStr(quarterStart);
   const qEndStr = toDateStr(quarterEnd.date);
   const hasCurrentQuarterlyReview = reviews.some(
     (r) => r.reviewType === 'quarterly' && r.periodStart === qStartStr && r.periodEnd === qEndStr,
   );
 
-  const completedReviews = reviews.slice(0, 6); // show latest 6
+  // -- Overdue checks --
+  // Weekly: overdue if last Sunday has passed and that week's review is missing
+  const lastSunday = getLastSunday();
+  const lastWeekStart = getWeekStartForSunday(lastSunday);
+  const lastWeekStartStr = toDateStr(lastWeekStart);
+  const lastSundayStr = toDateStr(lastSunday);
+  const isLastSundayPast = lastSunday < now;
+  const hasLastWeeklyReview = reviews.some(
+    (r) => r.reviewType === 'weekly' && r.periodStart === lastWeekStartStr && r.periodEnd === lastSundayStr,
+  );
+  const weeklyOverdue = isLastSundayPast && !hasLastWeeklyReview && lastSundayStr !== weekEndStr;
+  const weeklyOverdueDays = weeklyOverdue ? daysBetween(lastSunday, now) : 0;
+
+  // Quarterly: overdue if previous quarter end has passed and no review for it
+  const prevQEnd = getPreviousQuarterEnd();
+  const prevQEndStr = toDateStr(prevQEnd);
+  // Find the start of the previous quarter
+  const prevQEndDate = new Date(prevQEnd);
+  const prevQMonth = prevQEndDate.getMonth();
+  let prevQStartMonth: number;
+  if (prevQMonth < 3) prevQStartMonth = 0;
+  else if (prevQMonth < 6) prevQStartMonth = 3;
+  else if (prevQMonth < 9) prevQStartMonth = 6;
+  else prevQStartMonth = 9;
+  const prevQStart = new Date(prevQEndDate.getFullYear(), prevQStartMonth, 1);
+  const prevQStartStr = toDateStr(prevQStart);
+  const hasPrevQuarterlyReview = reviews.some(
+    (r) => r.reviewType === 'quarterly' && r.periodStart === prevQStartStr && r.periodEnd === prevQEndStr,
+  );
+  const quarterlyOverdue = !hasPrevQuarterlyReview && prevQEnd < now;
+  const quarterlyOverdueDays = quarterlyOverdue ? daysBetween(prevQEnd, now) : 0;
+  const prevQuarterMonth = prevQEnd.getMonth();
+  const prevQuarterLabel = `Q${Math.floor(prevQuarterMonth / 3) + 1} ${prevQEnd.getFullYear()}`;
+
+  // -- Completed reviews (most recent 6) --
+  const completedReviews = reviews.slice(0, 6);
 
   function handleStart(type: 'weekly' | 'quarterly') {
-    if (onStartReview) {
-      onStartReview(type);
-    }
     setActiveForm(type);
   }
 
-  // Notify parent when form is in view
-  const _ = activeForm; // used by internal state only
+  function handleCancel() {
+    setActiveForm(null);
+  }
+
+  function handleSaved() {
+    setActiveForm(null);
+  }
+
+  const hasOverdue = weeklyOverdue || quarterlyOverdue;
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl">
       {/* Header */}
       <div className="px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
@@ -143,70 +204,165 @@ export function ReviewsSchedule({ onStartReview }: ReviewsScheduleProps = {}) {
         </h2>
       </div>
 
-      {/* Upcoming */}
-      <div className="px-6 py-4">
-        <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
-          Upcoming
-        </span>
-        <div className="mt-3 space-y-2">
-          {/* Weekly review */}
-          <div className="flex items-center justify-between gap-4 py-2">
-            <div className="flex items-center gap-3 min-w-0">
-              {hasCurrentWeeklyReview ? (
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-success">
-                  <polyline points="3 7 6 10 11 4" />
-                </svg>
-              ) : (
-                <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0 text-text-muted">
-                  <circle cx="7" cy="7" r="5.5" fill="none" stroke="currentColor" strokeWidth="1" />
-                </svg>
-              )}
-              <span className="text-sm font-medium text-text">Weekly Review</span>
-              <span className="text-xs text-text-muted">
-                Due: {formatDateShort(nextSunday)}
-              </span>
-            </div>
-            {!hasCurrentWeeklyReview && (
-              <button
-                onClick={() => handleStart('weekly')}
-                className="text-xs font-bold uppercase tracking-wide text-accent hover:text-accent-hover transition-colors px-3 py-1 border border-accent/30 hover:border-accent/60"
-              >
-                Start
-              </button>
-            )}
+      {/* Inline form when active */}
+      {activeForm === 'weekly' && (
+        <div className="px-6 py-4 border-b border-border">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-xs font-bold uppercase tracking-widest text-accent">
+              Writing Weekly Review
+            </span>
+            <button
+              onClick={handleCancel}
+              className="text-xs font-bold uppercase tracking-wide text-text-muted hover:text-text transition-colors px-3 py-1 border border-border hover:border-text-muted rounded-lg"
+            >
+              Cancel
+            </button>
           </div>
+          <WeeklyReviewForm onSaved={handleSaved} />
+        </div>
+      )}
+      {activeForm === 'quarterly' && (
+        <div className="px-6 py-4 border-b border-border">
+          <div className="flex items-center justify-between mb-4">
+            <span className="text-xs font-bold uppercase tracking-widest text-accent">
+              Writing Quarterly Review
+            </span>
+            <button
+              onClick={handleCancel}
+              className="text-xs font-bold uppercase tracking-wide text-text-muted hover:text-text transition-colors px-3 py-1 border border-border hover:border-text-muted rounded-lg"
+            >
+              Cancel
+            </button>
+          </div>
+          <QuarterlyReviewForm onSaved={handleSaved} />
+        </div>
+      )}
 
-          {/* Quarterly review */}
-          <div className="flex items-center justify-between gap-4 py-2">
-            <div className="flex items-center gap-3 min-w-0">
-              {hasCurrentQuarterlyReview ? (
-                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-success">
-                  <polyline points="3 7 6 10 11 4" />
-                </svg>
-              ) : (
-                <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0 text-text-muted">
-                  <circle cx="7" cy="7" r="5.5" fill="none" stroke="currentColor" strokeWidth="1" />
-                </svg>
-              )}
-              <span className="text-sm font-medium text-text">Quarterly Review</span>
-              <span className="text-xs text-text-muted">
-                Due: {quarterEnd.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ({quarterEnd.label} end)
-              </span>
-            </div>
-            {!hasCurrentQuarterlyReview && (
-              <button
-                onClick={() => handleStart('quarterly')}
-                className="text-xs font-bold uppercase tracking-wide text-accent hover:text-accent-hover transition-colors px-3 py-1 border border-accent/30 hover:border-accent/60"
-              >
-                Start
-              </button>
+      {/* Overdue section */}
+      {hasOverdue && !activeForm && (
+        <div className="px-6 py-4 border-b border-border">
+          <span className="text-[10px] font-bold uppercase tracking-widest text-danger">
+            Overdue
+          </span>
+          <div className="mt-3 space-y-2">
+            {weeklyOverdue && (
+              <div className="flex items-center justify-between gap-4 py-3 px-4 border border-danger/30 bg-danger/5 rounded-lg">
+                <div className="flex items-center gap-3 min-w-0">
+                  <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0 text-danger">
+                    <circle cx="7" cy="7" r="5.5" fill="none" stroke="currentColor" strokeWidth="1.5" />
+                    <line x1="7" y1="4" x2="7" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    <circle cx="7" cy="10" r="0.75" fill="currentColor" />
+                  </svg>
+                  <span className="text-sm font-medium text-text">Weekly Review</span>
+                  <span className="text-xs font-medium text-danger bg-danger/10 px-2 py-0.5 rounded-full">
+                    Overdue
+                  </span>
+                  <span className="text-xs text-text-muted">
+                    {weeklyOverdueDays} day{weeklyOverdueDays !== 1 ? 's' : ''} overdue
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleStart('weekly')}
+                  className="text-xs font-bold uppercase tracking-wide text-danger hover:text-bg hover:bg-danger transition-colors px-3 py-1 border border-danger/40 hover:border-danger rounded-lg"
+                >
+                  Start Now
+                </button>
+              </div>
+            )}
+            {quarterlyOverdue && (
+              <div className="flex items-center justify-between gap-4 py-3 px-4 border border-danger/30 bg-danger/5 rounded-lg">
+                <div className="flex items-center gap-3 min-w-0">
+                  <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0 text-danger">
+                    <circle cx="7" cy="7" r="5.5" fill="none" stroke="currentColor" strokeWidth="1.5" />
+                    <line x1="7" y1="4" x2="7" y2="8" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+                    <circle cx="7" cy="10" r="0.75" fill="currentColor" />
+                  </svg>
+                  <span className="text-sm font-medium text-text">Quarterly Review ({prevQuarterLabel})</span>
+                  <span className="text-xs font-medium text-danger bg-danger/10 px-2 py-0.5 rounded-full">
+                    Overdue
+                  </span>
+                  <span className="text-xs text-text-muted">
+                    {quarterlyOverdueDays} day{quarterlyOverdueDays !== 1 ? 's' : ''} overdue
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleStart('quarterly')}
+                  className="text-xs font-bold uppercase tracking-wide text-danger hover:text-bg hover:bg-danger transition-colors px-3 py-1 border border-danger/40 hover:border-danger rounded-lg"
+                >
+                  Start Now
+                </button>
+              </div>
             )}
           </div>
         </div>
-      </div>
+      )}
 
-      {/* Completed */}
-      {completedReviews.length > 0 && (
+      {/* Upcoming section */}
+      {!activeForm && (
+        <div className="px-6 py-4">
+          <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
+            Upcoming
+          </span>
+          <div className="mt-3 space-y-2">
+            {/* Weekly review */}
+            <div className="flex items-center justify-between gap-4 py-3 px-4 border border-border rounded-lg">
+              <div className="flex items-center gap-3 min-w-0">
+                {hasCurrentWeeklyReview ? (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-success">
+                    <polyline points="3 7 6 10 11 4" />
+                  </svg>
+                ) : (
+                  <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0 text-text-muted">
+                    <circle cx="7" cy="7" r="5.5" fill="none" stroke="currentColor" strokeWidth="1" />
+                  </svg>
+                )}
+                <span className="text-sm font-medium text-text">Weekly Review</span>
+                <span className="text-xs text-text-muted">
+                  Due: {formatDateShort(nextSunday)}
+                </span>
+              </div>
+              {!hasCurrentWeeklyReview && (
+                <button
+                  onClick={() => handleStart('weekly')}
+                  className="text-xs font-bold uppercase tracking-wide text-accent hover:text-accent-hover transition-colors px-3 py-1 border border-accent/30 hover:border-accent/60 rounded-lg"
+                >
+                  Start
+                </button>
+              )}
+            </div>
+
+            {/* Quarterly review */}
+            <div className="flex items-center justify-between gap-4 py-3 px-4 border border-border rounded-lg">
+              <div className="flex items-center gap-3 min-w-0">
+                {hasCurrentQuarterlyReview ? (
+                  <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-success">
+                    <polyline points="3 7 6 10 11 4" />
+                  </svg>
+                ) : (
+                  <svg width="14" height="14" viewBox="0 0 14 14" className="shrink-0 text-text-muted">
+                    <circle cx="7" cy="7" r="5.5" fill="none" stroke="currentColor" strokeWidth="1" />
+                  </svg>
+                )}
+                <span className="text-sm font-medium text-text">Quarterly Review</span>
+                <span className="text-xs text-text-muted">
+                  Due: {quarterEnd.date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' })} ({quarterEnd.label} end)
+                </span>
+              </div>
+              {!hasCurrentQuarterlyReview && (
+                <button
+                  onClick={() => handleStart('quarterly')}
+                  className="text-xs font-bold uppercase tracking-wide text-accent hover:text-accent-hover transition-colors px-3 py-1 border border-accent/30 hover:border-accent/60 rounded-lg"
+                >
+                  Start
+                </button>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Completed section */}
+      {completedReviews.length > 0 && !activeForm && (
         <div className="px-6 py-4 border-t border-border">
           <span className="text-[10px] font-bold uppercase tracking-widest text-text-muted">
             Completed
@@ -222,21 +378,21 @@ export function ReviewsSchedule({ onStartReview }: ReviewsScheduleProps = {}) {
               return (
                 <div
                   key={review._id}
-                  className="flex items-center justify-between gap-4 py-2"
+                  className="flex items-center justify-between gap-4 py-2 px-4 rounded-lg opacity-75 hover:opacity-100 transition-opacity"
                 >
                   <div className="flex items-center gap-3 min-w-0">
                     <svg width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" className="shrink-0 text-success">
                       <polyline points="3 7 6 10 11 4" />
                     </svg>
-                    <span className="text-sm text-text">{typeLabel}</span>
-                    <span className="text-xs text-text-muted">
+                    <span className="text-sm text-text-muted">{typeLabel}</span>
+                    <span className="text-xs text-text-muted/70">
                       {formatDateRange(review.periodStart, review.periodEnd)}
                     </span>
                   </div>
                   {review.score != null && (
                     <div className="flex items-baseline gap-1 shrink-0">
-                      <span className="text-sm font-bold text-text">{review.score}</span>
-                      <span className="text-[10px] text-text-muted">/10</span>
+                      <span className="text-sm font-bold text-text-muted">{review.score}</span>
+                      <span className="text-[10px] text-text-muted/70">/10</span>
                     </div>
                   )}
                 </div>

--- a/web/src/components/sections/reviews-timeline.tsx
+++ b/web/src/components/sections/reviews-timeline.tsx
@@ -226,7 +226,13 @@ export function ReviewsTimeline() {
   const reviews = useQuery(api.reviews.list, {});
   const [expandedId, setExpandedId] = useState<string | null>(null);
 
-  if (!reviews) return <div className="text-text-muted">Loading...</div>;
+  if (!reviews) return (
+    <div className="space-y-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="h-16 rounded-xl bg-surface animate-pulse" />
+      ))}
+    </div>
+  );
 
   return (
     <div className="max-w-none space-y-8">
@@ -241,7 +247,7 @@ export function ReviewsTimeline() {
           <p className="text-sm text-text-muted mt-1">Complete a daily or weekly review to see it here.</p>
         </div>
       ) : (
-        <div className="border border-border divide-y divide-border">
+        <div className="border border-border rounded-xl overflow-hidden divide-y divide-border">
           {reviews.map((review, idx: number) => {
             const reviewType = review.reviewType;
             const typeLabel = reviewTypeLabel[reviewType] ?? reviewType;

--- a/web/src/components/sections/tasks-bucketed.tsx
+++ b/web/src/components/sections/tasks-bucketed.tsx
@@ -3,10 +3,10 @@
 import { useState, useRef, useEffect, useCallback } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
-import type { Id } from '@/lib/convex-api';
-import { formatDate } from '@/lib/utils';
-import { TaskForm } from '@/components/task-form';
-import type { Doc } from '../../../../../convex/_generated/dataModel';
+import type { Id, Doc } from '@/lib/convex-api';
+import { TaskDetailModal } from '@/components/task-detail-modal';
+import { HoverActionsMenu, type HoverAction } from '@/components/hover-actions-menu';
+import { ContextMenu, type ContextMenuItem } from '@/components/context-menu';
 
 // ── Date helpers ─────────────────────────────────────
 
@@ -34,7 +34,7 @@ function sevenDaysFromNowISO(): string {
 
 function nextMondayISO(): string {
   const d = new Date();
-  const day = d.getDay(); // 0=Sun, 1=Mon, ...
+  const day = d.getDay();
   const daysUntilMonday = day === 0 ? 1 : 8 - day;
   d.setDate(d.getDate() + daysUntilMonday);
   return d.toISOString().slice(0, 10);
@@ -51,10 +51,26 @@ function weekdayName(dateStr: string): string {
   return d.toLocaleDateString('en-US', { weekday: 'long' });
 }
 
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
 function shortDate(dateStr: string | undefined | null): string {
   if (!dateStr) return 'No date';
   const d = new Date(dateStr + 'T00:00:00');
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return d.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function columnHeaderDate(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  const day = d.getDate();
+  const month = d.toLocaleDateString('en-US', { month: 'short' });
+  return `${day} ${month}`;
+}
+
+function toISO(year: number, month: number, day: number): string {
+  return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
 }
 
 // ── Bucket types ─────────────────────────────────────
@@ -64,9 +80,11 @@ type Task = Doc<'tasks'>;
 interface TaskBucket {
   key: string;
   label: string;
+  sublabel?: string;
   count: number;
   variant: 'danger' | 'default' | 'muted';
   tasks: Task[];
+  defaultDate?: string;
 }
 
 function bucketTasks(tasks: Task[]): TaskBucket[] {
@@ -81,11 +99,12 @@ function bucketTasks(tasks: Task[]): TaskBucket[] {
   const dayAfterBucket: Task[] = [];
   const nextSevenDays: Task[] = [];
   const later: Task[] = [];
+  const noDate: Task[] = [];
 
   for (const task of tasks) {
     const due = task.dueDate ?? null;
     if (!due) {
-      later.push(task);
+      noDate.push(task);
     } else if (due < today) {
       overdue.push(task);
     } else if (due === today) {
@@ -101,32 +120,81 @@ function bucketTasks(tasks: Task[]): TaskBucket[] {
     }
   }
 
-  const dayAfterLabel = weekdayName(dayAfter);
+  const tomorrowDay = weekdayName(tomorrow);
 
   const buckets: TaskBucket[] = [];
   if (overdue.length > 0) {
-    buckets.push({ key: 'overdue', label: 'Overdue', count: overdue.length, variant: 'danger', tasks: overdue });
+    buckets.push({ key: 'overdue', label: 'Overdue', count: overdue.length, variant: 'danger', tasks: overdue, defaultDate: today });
   }
-  buckets.push({ key: 'today', label: 'Today', count: todayBucket.length, variant: 'default', tasks: todayBucket });
-  buckets.push({ key: 'tomorrow', label: 'Tomorrow', count: tomorrowBucket.length, variant: 'muted', tasks: tomorrowBucket });
-  buckets.push({ key: 'dayafter', label: dayAfterLabel, count: dayAfterBucket.length, variant: 'muted', tasks: dayAfterBucket });
-  buckets.push({ key: 'next7d', label: 'Next 7d', count: nextSevenDays.length, variant: 'muted', tasks: nextSevenDays });
-  buckets.push({ key: 'later', label: 'Later', count: later.length, variant: 'muted', tasks: later });
+  buckets.push({
+    key: 'today',
+    label: `${columnHeaderDate(today)}`,
+    sublabel: 'Today',
+    count: todayBucket.length,
+    variant: 'default',
+    tasks: todayBucket,
+    defaultDate: today,
+  });
+  buckets.push({
+    key: 'tomorrow',
+    label: `${columnHeaderDate(tomorrow)}`,
+    sublabel: tomorrowDay,
+    count: tomorrowBucket.length,
+    variant: 'muted',
+    tasks: tomorrowBucket,
+    defaultDate: tomorrow,
+  });
+  if (dayAfterBucket.length > 0) {
+    const dayAfterDay = weekdayName(dayAfter);
+    buckets.push({
+      key: 'dayafter',
+      label: `${columnHeaderDate(dayAfter)}`,
+      sublabel: dayAfterDay,
+      count: dayAfterBucket.length,
+      variant: 'muted',
+      tasks: dayAfterBucket,
+      defaultDate: dayAfter,
+    });
+  }
+  if (nextSevenDays.length > 0) {
+    buckets.push({ key: 'next7d', label: 'Next 7 days', count: nextSevenDays.length, variant: 'muted', tasks: nextSevenDays, defaultDate: sevenDays });
+  }
+  if (later.length > 0) {
+    buckets.push({ key: 'later', label: 'Later', count: later.length, variant: 'muted', tasks: later });
+  }
+  buckets.push({ key: 'nodate', label: 'No date', count: noDate.length, variant: 'muted', tasks: noDate });
 
   return buckets;
 }
 
-// ── Quick Date Picker ────────────────────────────────
+// ── Calendar Date Picker ─────────────────────────────
 
-interface QuickDatePickerProps {
+interface CalendarDatePickerProps {
   currentDate: string | undefined;
   onSelect: (date: string | null) => void;
   onClose: () => void;
 }
 
-function QuickDatePicker({ currentDate, onSelect, onClose }: QuickDatePickerProps) {
+function CalendarDatePicker({ currentDate, onSelect, onClose }: CalendarDatePickerProps) {
   const ref = useRef<HTMLDivElement>(null);
-  const [customDate, setCustomDate] = useState(currentDate ?? '');
+
+  const todayStr = todayISO();
+  const todayDate = new Date(todayStr + 'T00:00:00');
+
+  const [viewYear, setViewYear] = useState(() => {
+    if (currentDate) {
+      const d = new Date(currentDate + 'T00:00:00');
+      return d.getFullYear();
+    }
+    return todayDate.getFullYear();
+  });
+  const [viewMonth, setViewMonth] = useState(() => {
+    if (currentDate) {
+      const d = new Date(currentDate + 'T00:00:00');
+      return d.getMonth();
+    }
+    return todayDate.getMonth();
+  });
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -138,68 +206,207 @@ function QuickDatePicker({ currentDate, onSelect, onClose }: QuickDatePickerProp
     return () => document.removeEventListener('mousedown', handleClickOutside);
   }, [onClose]);
 
+  const goToPrevMonth = () => {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear(viewYear - 1);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  };
+
+  const goToNextMonth = () => {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear(viewYear + 1);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  };
+
+  const goToToday = () => {
+    setViewYear(todayDate.getFullYear());
+    setViewMonth(todayDate.getMonth());
+  };
+
+  // Build calendar grid
+  const firstDayOfMonth = new Date(viewYear, viewMonth, 1);
+  // Monday = 0, Sunday = 6
+  let startDow = firstDayOfMonth.getDay() - 1;
+  if (startDow < 0) startDow = 6;
+
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const daysInPrevMonth = new Date(viewYear, viewMonth, 0).getDate();
+
+  const calendarDays: Array<{ day: number; month: number; year: number; isCurrentMonth: boolean }> = [];
+
+  // Previous month fill
+  for (let i = startDow - 1; i >= 0; i--) {
+    const prevMonth = viewMonth === 0 ? 11 : viewMonth - 1;
+    const prevYear = viewMonth === 0 ? viewYear - 1 : viewYear;
+    calendarDays.push({ day: daysInPrevMonth - i, month: prevMonth, year: prevYear, isCurrentMonth: false });
+  }
+
+  // Current month
+  for (let d = 1; d <= daysInMonth; d++) {
+    calendarDays.push({ day: d, month: viewMonth, year: viewYear, isCurrentMonth: true });
+  }
+
+  // Next month fill (to complete 6 rows max, or at least fill the last row)
+  const remaining = 7 - (calendarDays.length % 7);
+  if (remaining < 7) {
+    const nextMonth = viewMonth === 11 ? 0 : viewMonth + 1;
+    const nextYear = viewMonth === 11 ? viewYear + 1 : viewYear;
+    for (let d = 1; d <= remaining; d++) {
+      calendarDays.push({ day: d, month: nextMonth, year: nextYear, isCurrentMonth: false });
+    }
+  }
+
+  const monthLabel = new Date(viewYear, viewMonth, 1).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  const weekDays = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+
   const quickOptions = [
-    { label: 'Today', date: todayISO() },
-    { label: 'Tomorrow', date: tomorrowISO() },
-    { label: 'Next Monday', date: nextMondayISO() },
-    { label: 'Next Week', date: nextWeekISO() },
-    { label: 'No Date', date: null },
+    { label: 'Today', date: todayISO(), icon: '☀' },
+    { label: 'Tomorrow', date: tomorrowISO(), icon: '→' },
+    { label: 'Next Monday', date: nextMondayISO(), icon: '📅' },
+    { label: 'Next Week', date: nextWeekISO(), icon: '⏭' },
+    { label: 'No Date', date: null, icon: '✕' },
   ];
 
   return (
     <div
       ref={ref}
-      className="absolute z-50 top-full left-0 mt-1 w-52 border border-border bg-bg shadow-lg p-2 space-y-1"
+      className="absolute z-50 top-full left-0 mt-1 w-[280px] border border-border bg-surface rounded-xl shadow-xl overflow-hidden"
+      onClick={(e) => e.stopPropagation()}
     >
-      {quickOptions.map((opt) => {
-        const isActive = opt.date === (currentDate ?? null);
-        return (
-          <button
-            key={opt.label}
-            type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              onSelect(opt.date);
-            }}
-            className={`w-full text-left px-3 py-1.5 text-xs rounded transition-colors ${
-              isActive
-                ? 'bg-accent/10 text-accent font-medium'
-                : 'text-text hover:bg-surface-hover'
-            }`}
-          >
-            <span>{opt.label}</span>
-            {opt.date && (
-              <span className="float-right text-text-muted font-mono">
-                {shortDate(opt.date)}
-              </span>
-            )}
-          </button>
-        );
-      })}
-      <div className="border-t border-border pt-2 mt-2">
-        <label className="block text-xs text-text-muted mb-1 px-1">Custom date</label>
-        <div className="flex gap-1">
-          <input
-            type="date"
-            value={customDate}
-            onChange={(e) => setCustomDate(e.target.value)}
-            className="flex-1 rounded border border-border bg-bg px-2 py-1 text-xs text-text focus:border-accent focus:outline-none"
-            onClick={(e) => e.stopPropagation()}
-          />
+      {/* Month header */}
+      <div className="flex items-center justify-between px-3 pt-3 pb-2">
+        <button
+          type="button"
+          onClick={goToPrevMonth}
+          className="p-1 rounded-md text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+          aria-label="Previous month"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-text">{monthLabel}</span>
           <button
             type="button"
-            onClick={(e) => {
-              e.stopPropagation();
-              if (customDate) onSelect(customDate);
-            }}
-            disabled={!customDate}
-            className="rounded bg-text px-2 py-1 text-xs text-bg hover:bg-accent-hover disabled:opacity-40 transition-colors"
+            onClick={goToToday}
+            className="text-[10px] text-text-muted hover:text-accent px-1.5 py-0.5 rounded-md hover:bg-surface-hover transition-colors"
           >
-            Set
+            Today
           </button>
         </div>
+        <button
+          type="button"
+          onClick={goToNextMonth}
+          className="p-1 rounded-md text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+          aria-label="Next month"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </button>
       </div>
+
+      {/* Weekday headers */}
+      <div className="grid grid-cols-7 px-3 pb-1">
+        {weekDays.map((wd) => (
+          <div key={wd} className="text-center text-[10px] font-medium text-text-muted/50 py-1">
+            {wd}
+          </div>
+        ))}
+      </div>
+
+      {/* Calendar grid */}
+      <div className="grid grid-cols-7 px-3 pb-2">
+        {calendarDays.map((cd, idx) => {
+          const dateStr = toISO(cd.year, cd.month, cd.day);
+          const isToday = dateStr === todayStr;
+          const isSelected = dateStr === currentDate;
+
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => onSelect(dateStr)}
+              className={`
+                h-8 w-full flex items-center justify-center text-[11px] rounded-lg transition-all duration-100
+                ${!cd.isCurrentMonth ? 'text-text-muted/25' : ''}
+                ${cd.isCurrentMonth && !isToday && !isSelected ? 'text-text hover:bg-surface-hover' : ''}
+                ${isToday && !isSelected ? 'text-accent font-bold bg-accent/10' : ''}
+                ${isSelected ? 'bg-accent text-bg font-bold' : ''}
+              `}
+            >
+              {cd.day}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Divider */}
+      <div className="border-t border-border/40" />
+
+      {/* Quick options */}
+      <div className="p-2 space-y-0.5">
+        {quickOptions.map((opt) => {
+          const isActive = opt.date === (currentDate ?? null);
+          return (
+            <button
+              key={opt.label}
+              type="button"
+              onClick={() => onSelect(opt.date)}
+              className={`w-full text-left px-3 py-1.5 text-xs rounded-lg transition-colors flex items-center gap-2 ${
+                isActive
+                  ? 'bg-accent/10 text-accent font-medium'
+                  : 'text-text hover:bg-surface-hover'
+              }`}
+            >
+              <span className="text-[11px] w-4 text-center opacity-60">{opt.icon}</span>
+              <span>{opt.label}</span>
+              {opt.date && (
+                <span className="ml-auto text-text-muted font-mono text-[10px]">
+                  {shortDate(opt.date)}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Clear button */}
+      {currentDate && (
+        <>
+          <div className="border-t border-border/40" />
+          <div className="p-2">
+            <button
+              type="button"
+              onClick={() => onSelect(null)}
+              className="w-full text-center text-xs text-text-muted hover:text-danger py-1.5 rounded-lg hover:bg-surface-hover transition-colors"
+            >
+              Clear date
+            </button>
+          </div>
+        </>
+      )}
     </div>
+  );
+}
+
+// ── Calendar Icon ───────────────────────────────────
+
+function CalendarIcon({ className }: { className?: string }) {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
   );
 }
 
@@ -207,14 +414,38 @@ function QuickDatePicker({ currentDate, onSelect, onClose }: QuickDatePickerProp
 
 interface TaskCardProps {
   task: Task;
+  showDate?: boolean;
+  bucketKey: string;
+  isSelected?: boolean;
+  onDragStart: (e: React.DragEvent, taskId: string, bucketKey: string) => void;
+  onClick?: (e: React.MouseEvent) => void;
+  onComplete?: () => Promise<void>;
+  onDelete?: () => Promise<void>;
+  onRescheduleToday?: () => Promise<void>;
+  onRescheduleTomorrow?: () => Promise<void>;
+  onRemoveDate?: () => Promise<void>;
 }
 
-function TaskCard({ task }: TaskCardProps) {
+function TaskCard({ task, showDate = true, bucketKey, isSelected = false, onDragStart, onClick, onComplete, onDelete, onRescheduleToday, onRescheduleTomorrow, onRemoveDate }: TaskCardProps) {
   const [datePickerOpen, setDatePickerOpen] = useState(false);
   const [completing, setCompleting] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [editTitle, setEditTitle] = useState(task.title);
 
   const completeTask = useMutation(api.tasks.complete);
   const updateTask = useMutation(api.tasks.update);
+
+  const handleSave = useCallback(async () => {
+    const trimmed = editTitle.trim();
+    if (trimmed && trimmed !== task.title) {
+      try {
+        await updateTask({ id: task._id, title: trimmed });
+      } catch (err) {
+        console.error('Failed to update task title:', err);
+      }
+    }
+    setEditing(false);
+  }, [editTitle, task.title, task._id, updateTask]);
 
   const handleComplete = useCallback(async (e: React.MouseEvent) => {
     e.stopPropagation();
@@ -237,12 +468,6 @@ function TaskCard({ task }: TaskCardProps) {
       if (date !== null) {
         args.dueDate = date;
       } else {
-        // Setting to empty string to clear. The update handler checks undefined vs provided.
-        // Since the schema allows optional string, we pass empty string to represent "cleared".
-        // Actually, looking at the update mutation, it checks `!== undefined` to decide patching.
-        // We need to pass dueDate to clear it. Convex patch with undefined won't unset the field,
-        // but the update mutation sets `updates.dueDate = args.dueDate` when provided.
-        // For "No Date", we send an empty string which effectively removes the date display.
         args.dueDate = '';
       }
       await updateTask(args);
@@ -252,53 +477,404 @@ function TaskCard({ task }: TaskCardProps) {
   }, [updateTask, task._id]);
 
   const dueDate = task.dueDate ?? null;
+  const isOverdue = dueDate && dueDate < todayISO();
+
+  const hoverActions: HoverAction[] = [
+    {
+      label: 'Edit',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+        </svg>
+      ),
+      onClick: () => onClick?.({ stopPropagation: () => {}, preventDefault: () => {} } as React.MouseEvent),
+    },
+    {
+      label: 'Complete',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onComplete) void onComplete();
+        else void handleComplete({ stopPropagation: () => {}, preventDefault: () => {} } as React.MouseEvent);
+      },
+    },
+    {
+      label: 'Set as MIT',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+        </svg>
+      ),
+      onClick: () => {
+        // Future: assign as MIT via day plan upsert
+      },
+    },
+    {
+      label: 'Reschedule: Today',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 14" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onRescheduleToday) void onRescheduleToday();
+        else void updateTask({ id: task._id, dueDate: todayISO() });
+      },
+    },
+    {
+      label: 'Reschedule: Tomorrow',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="5" y1="12" x2="19" y2="12" />
+          <polyline points="12 5 19 12 12 19" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onRescheduleTomorrow) void onRescheduleTomorrow();
+        else void updateTask({ id: task._id, dueDate: tomorrowISO() });
+      },
+    },
+    {
+      label: 'Remove date',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+          <line x1="9" y1="14" x2="15" y2="18" />
+          <line x1="15" y1="14" x2="9" y2="18" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onRemoveDate) void onRemoveDate();
+        else void updateTask({ id: task._id, dueDate: '' });
+      },
+    },
+    {
+      label: 'Delete',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+        </svg>
+      ),
+      variant: 'danger' as const,
+      onClick: () => {
+        if (onDelete) void onDelete();
+      },
+    },
+  ];
+
+  const contextMenuItems: ContextMenuItem[] = [
+    {
+      label: 'Edit',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+          <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+        </svg>
+      ),
+      onClick: () => onClick?.({ stopPropagation: () => {}, preventDefault: () => {} } as React.MouseEvent),
+    },
+    {
+      label: 'Complete',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onComplete) void onComplete();
+        else void handleComplete({ stopPropagation: () => {}, preventDefault: () => {} } as React.MouseEvent);
+      },
+    },
+    {
+      label: 'Reschedule: Today',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="12" cy="12" r="10" />
+          <polyline points="12 6 12 12 16 14" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onRescheduleToday) void onRescheduleToday();
+        else void updateTask({ id: task._id, dueDate: todayISO() });
+      },
+    },
+    {
+      label: 'Reschedule: Tomorrow',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <line x1="5" y1="12" x2="19" y2="12" />
+          <polyline points="12 5 19 12 12 19" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onRescheduleTomorrow) void onRescheduleTomorrow();
+        else void updateTask({ id: task._id, dueDate: tomorrowISO() });
+      },
+    },
+    {
+      label: 'Remove date',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+          <line x1="16" y1="2" x2="16" y2="6" />
+          <line x1="8" y1="2" x2="8" y2="6" />
+          <line x1="3" y1="10" x2="21" y2="10" />
+          <line x1="9" y1="14" x2="15" y2="18" />
+          <line x1="15" y1="14" x2="9" y2="18" />
+        </svg>
+      ),
+      onClick: () => {
+        if (onRemoveDate) void onRemoveDate();
+        else void updateTask({ id: task._id, dueDate: '' });
+      },
+    },
+    {
+      label: 'Delete',
+      icon: (
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="3 6 5 6 21 6" />
+          <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+        </svg>
+      ),
+      variant: 'danger' as const,
+      divider: true,
+      onClick: () => {
+        if (onDelete) void onDelete();
+      },
+    },
+  ];
 
   return (
-    <div className="group px-3 py-2.5 hover:bg-surface-hover transition-colors">
-      <div className="flex items-start gap-2.5">
-        {/* Checkbox circle */}
-        <button
-          type="button"
-          onClick={handleComplete}
-          disabled={completing}
-          className={`mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border transition-colors ${
-            completing
-              ? 'border-success bg-success/20'
-              : 'border-text-muted/40 hover:border-accent hover:bg-accent/10'
-          }`}
-          aria-label={`Complete "${task.title}"`}
-        >
-          {completing && (
-            <svg width="8" height="8" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="text-success">
-              <polyline points="20 6 9 17 4 12" />
-            </svg>
-          )}
-        </button>
+    <ContextMenu items={contextMenuItems}>
+      <div
+        draggable
+        onDragStart={(e) => onDragStart(e, task._id, bucketKey)}
+        onClick={onClick}
+        className={`group relative rounded-xl border transition-all duration-150 cursor-grab active:cursor-grabbing ${
+          isSelected
+            ? 'border-accent/40 bg-surface ring-2 ring-accent/40'
+            : editing
+              ? 'border-accent/30 bg-surface ring-2 ring-accent/20'
+              : 'border-border bg-surface hover:border-text-muted/30'
+        }`}
+      >
+        {/* Selection indicator */}
+        {isSelected && (
+          <div className="absolute top-2 left-2 h-4 w-4 rounded bg-accent flex items-center justify-center z-10">
+            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="3"><polyline points="20 6 9 17 4 12" /></svg>
+          </div>
+        )}
 
-        {/* Content */}
-        <div className="flex-1 min-w-0">
-          <p className="text-sm text-text leading-tight truncate">{task.title}</p>
+        {/* Hover actions menu */}
+        <div className="absolute top-2 right-2 z-10">
+          <HoverActionsMenu actions={hoverActions} />
+        </div>
 
-          {/* Date label - clickable */}
-          <div className="relative mt-1">
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                setDatePickerOpen((prev) => !prev);
-              }}
-              className="text-[11px] font-mono text-text-muted hover:text-accent transition-colors"
-            >
-              {dueDate ? shortDate(dueDate) : 'No date'}
-            </button>
-            {datePickerOpen && (
-              <QuickDatePicker
-                currentDate={dueDate ?? undefined}
-                onSelect={handleDateSelect}
-                onClose={() => setDatePickerOpen(false)}
+        <div className="px-3.5 py-3 flex items-start gap-3">
+          {/* Checkbox circle */}
+          <button
+            type="button"
+            onClick={handleComplete}
+            disabled={completing}
+            className={`mt-0.5 flex h-[18px] w-[18px] shrink-0 items-center justify-center rounded-full border-[1.5px] transition-all duration-150 ${
+              completing
+                ? 'border-success bg-success/20'
+                : isOverdue
+                  ? 'border-danger/60 hover:border-danger hover:bg-danger/10'
+                  : 'border-text-muted/30 hover:border-accent hover:bg-accent/10'
+            }`}
+            aria-label={`Complete "${task.title}"`}
+          >
+            {completing && (
+              <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="text-success">
+                <polyline points="20 6 9 17 4 12" />
+              </svg>
+            )}
+          </button>
+
+          {/* Content */}
+          <div className="flex-1 min-w-0 pr-6">
+            {editing ? (
+              <input
+                autoFocus
+                value={editTitle}
+                onChange={(e) => setEditTitle(e.target.value)}
+                onBlur={() => void handleSave()}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') void handleSave();
+                  if (e.key === 'Escape') { setEditing(false); setEditTitle(task.title); }
+                }}
+                className="w-full bg-transparent text-[13px] text-text focus:outline-none"
+                onClick={(e) => e.stopPropagation()}
               />
+            ) : (
+              <p
+                className="text-[13px] text-text leading-snug cursor-text"
+                onDoubleClick={(e) => { e.stopPropagation(); setEditing(true); setEditTitle(task.title); }}
+              >
+                {task.title}
+              </p>
+            )}
+            {task.notes && (
+              <p className="text-[11px] text-text-muted mt-0.5 truncate leading-snug">{task.notes}</p>
+            )}
+
+            {/* Date badge - clickable */}
+            {showDate && (
+              <div className="relative mt-1.5">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setDatePickerOpen((prev) => !prev);
+                  }}
+                  className={`inline-flex items-center gap-1 text-[11px] transition-colors rounded-md px-1 py-0.5 -ml-1 ${
+                    isOverdue
+                      ? 'text-danger hover:bg-danger/10'
+                      : 'text-text-muted hover:text-accent hover:bg-surface-hover'
+                  }`}
+                >
+                  <CalendarIcon className={isOverdue ? 'text-danger' : 'opacity-50'} />
+                  {dueDate ? formatDateLabel(dueDate) : 'No date'}
+                </button>
+                {datePickerOpen && (
+                  <CalendarDatePicker
+                    currentDate={dueDate ?? undefined}
+                    onSelect={handleDateSelect}
+                    onClose={() => setDatePickerOpen(false)}
+                  />
+                )}
+              </div>
             )}
           </div>
+        </div>
+      </div>
+    </ContextMenu>
+  );
+}
+
+// ── Inline Add Task ─────────────────────────────────
+
+function InlineAddTask({ defaultDate, onDone }: { defaultDate?: string; onDone?: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [dueDate, setDueDate] = useState(defaultDate ?? todayISO());
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const createTask = useMutation(api.tasks.create);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (open) {
+      inputRef.current?.focus();
+    }
+  }, [open]);
+
+  const handleSubmit = async () => {
+    if (!title.trim() || saving) return;
+    setSaving(true);
+    try {
+      const args: { title: string; dueDate?: string } = { title: title.trim() };
+      if (dueDate) args.dueDate = dueDate;
+      await createTask(args);
+      setTitle('');
+      setDueDate(defaultDate ?? todayISO());
+      // Keep open for rapid entry
+      inputRef.current?.focus();
+      onDone?.();
+    } catch (err) {
+      console.error('Failed to create task:', err);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      void handleSubmit();
+    }
+    if (e.key === 'Escape') {
+      setOpen(false);
+      setTitle('');
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="flex items-center gap-2 px-3.5 py-2.5 w-full text-text-muted hover:text-accent transition-colors group/add"
+      >
+        <span className="flex h-[18px] w-[18px] items-center justify-center rounded-full border-[1.5px] border-dashed border-text-muted/30 group-hover/add:border-accent/50 transition-colors">
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="5" x2="12" y2="19" />
+            <line x1="5" y1="12" x2="19" y2="12" />
+          </svg>
+        </span>
+        <span className="text-[13px]">Add task</span>
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-accent/40 bg-surface p-3 mx-0">
+      <input
+        ref={inputRef}
+        type="text"
+        placeholder="Task name"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        onKeyDown={handleKeyDown}
+        className="w-full bg-transparent text-[13px] text-text placeholder:text-text-muted/50 focus:outline-none"
+      />
+      <div className="flex items-center justify-between mt-2.5">
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setDatePickerOpen((prev) => !prev)}
+            className="inline-flex items-center gap-1 text-[11px] text-text-muted hover:text-accent transition-colors rounded-md px-1.5 py-1 hover:bg-surface-hover"
+          >
+            <CalendarIcon className="opacity-50" />
+            {dueDate ? shortDate(dueDate) : 'Today'}
+          </button>
+          {datePickerOpen && (
+            <CalendarDatePicker
+              currentDate={dueDate || undefined}
+              onSelect={(date) => {
+                setDueDate(date ?? '');
+                setDatePickerOpen(false);
+              }}
+              onClose={() => setDatePickerOpen(false)}
+            />
+          )}
+        </div>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => { setOpen(false); setTitle(''); }}
+            className="text-[11px] text-text-muted hover:text-text px-2 py-1 rounded-lg transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={!title.trim() || saving}
+            className="text-[11px] font-medium bg-accent text-bg px-3 py-1 rounded-lg hover:bg-accent-hover disabled:opacity-30 transition-colors"
+          >
+            {saving ? '...' : 'Add'}
+          </button>
         </div>
       </div>
     </div>
@@ -309,41 +885,163 @@ function TaskCard({ task }: TaskCardProps) {
 
 interface BucketColumnProps {
   bucket: TaskBucket;
+  dragOverKey: string | null;
+  selectedIds: Set<string>;
+  onDragStart: (e: React.DragEvent, taskId: string, bucketKey: string) => void;
+  onDragOver: (e: React.DragEvent, bucketKey: string) => void;
+  onDragLeave: (e: React.DragEvent) => void;
+  onDrop: (e: React.DragEvent, bucket: TaskBucket) => void;
+  onReorder: (taskId: Id<'tasks'>, targetIndex: number, bucket: TaskBucket) => void;
+  onTaskClick: (taskId: Id<'tasks'>, e: React.MouseEvent) => void;
+  onTaskComplete: (taskId: Id<'tasks'>) => Promise<void>;
+  onTaskDelete: (taskId: Id<'tasks'>) => Promise<void>;
+  onTaskReschedule: (taskId: Id<'tasks'>, date: string) => Promise<void>;
+  onTaskRemoveDate: (taskId: Id<'tasks'>) => Promise<void>;
 }
 
-function BucketColumn({ bucket }: BucketColumnProps) {
-  const headerColor =
-    bucket.variant === 'danger'
-      ? 'text-danger border-danger/30'
-      : bucket.variant === 'default'
-        ? 'text-text border-text/20'
-        : 'text-text-muted border-border';
+function BucketColumn({ bucket, dragOverKey, selectedIds, onDragStart, onDragOver, onDragLeave, onDrop, onReorder, onTaskClick, onTaskComplete, onTaskDelete, onTaskReschedule, onTaskRemoveDate }: BucketColumnProps) {
+  const isDragOver = dragOverKey === bucket.key;
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null);
+
+  const handleTaskDragOver = useCallback((e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const sourceBucket = e.dataTransfer.types.includes('application/x-source-bucket');
+    if (sourceBucket) {
+      setDragOverIndex(index);
+    }
+  }, []);
+
+  const handleTaskDrop = useCallback((e: React.DragEvent, index: number) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverIndex(null);
+
+    const sourceBucket = e.dataTransfer.getData('application/x-source-bucket');
+    const taskId = e.dataTransfer.getData('text/plain');
+    if (!taskId) return;
+
+    if (sourceBucket === bucket.key) {
+      // Same-column reorder
+      onReorder(taskId as Id<'tasks'>, index, bucket);
+    } else {
+      // Cross-column move -- delegate to parent
+      onDrop(e, bucket);
+    }
+  }, [bucket, onReorder, onDrop]);
+
+  const handleColumnDragLeave = useCallback((e: React.DragEvent) => {
+    const relatedTarget = e.relatedTarget as Node | null;
+    if (e.currentTarget instanceof HTMLElement && relatedTarget && e.currentTarget.contains(relatedTarget)) {
+      return;
+    }
+    setDragOverIndex(null);
+    onDragLeave(e);
+  }, [onDragLeave]);
+
+  const handleEndZoneDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverIndex(bucket.tasks.length);
+  }, [bucket.tasks.length]);
+
+  const handleEndZoneDrop = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOverIndex(null);
+
+    const sourceBucket = e.dataTransfer.getData('application/x-source-bucket');
+    const taskId = e.dataTransfer.getData('text/plain');
+    if (!taskId) return;
+
+    if (sourceBucket === bucket.key) {
+      onReorder(taskId as Id<'tasks'>, bucket.tasks.length, bucket);
+    } else {
+      onDrop(e, bucket);
+    }
+  }, [bucket, onReorder, onDrop]);
 
   return (
-    <div className="min-w-[220px] max-w-[280px] flex-1 flex flex-col border border-border">
+    <div
+      className={`min-w-[260px] max-w-[320px] flex-1 flex flex-col rounded-xl transition-all duration-150 ${
+        isDragOver ? 'bg-accent/5 ring-2 ring-accent/30 ring-inset' : ''
+      }`}
+      onDragOver={(e) => onDragOver(e, bucket.key)}
+      onDragLeave={handleColumnDragLeave}
+      onDrop={(e) => onDrop(e, bucket)}
+    >
       {/* Column header */}
-      <div className={`px-3 py-2.5 border-b ${headerColor} bg-surface`}>
-        <div className="flex items-center justify-between">
-          <span className="text-xs font-bold uppercase tracking-widest">
-            {bucket.label}
+      <div className="px-2 pb-3 pt-1 flex items-baseline gap-2">
+        <span className={`text-sm font-semibold ${
+          bucket.variant === 'danger' ? 'text-danger' : 'text-text'
+        }`}>
+          {bucket.sublabel && (
+            <>
+              <span className="text-text-muted">{bucket.label}</span>
+              <span className="mx-1.5 text-text-muted/30">&middot;</span>
+            </>
+          )}
+          {bucket.sublabel ?? bucket.label}
+        </span>
+        <span className="text-xs text-text-muted/50 font-medium tabular-nums">
+          {bucket.count}
+        </span>
+        {bucket.variant === 'danger' && bucket.count > 0 && (
+          <span className="text-[11px] text-danger/70 font-medium ml-auto cursor-default">
+            Reschedule
           </span>
-          <span className="text-xs font-mono opacity-60">
-            {bucket.count}
-          </span>
-        </div>
+        )}
       </div>
 
       {/* Task cards */}
-      <div className="flex-1 divide-y divide-border overflow-y-auto">
-        {bucket.tasks.length === 0 ? (
-          <div className="px-3 py-6 text-center">
-            <p className="text-xs text-text-muted">No tasks</p>
+      <div className="flex flex-col gap-2 px-1">
+        {bucket.tasks.map((task, index) => (
+          <div
+            key={task._id}
+            onDragOver={(e) => handleTaskDragOver(e, index)}
+            onDrop={(e) => handleTaskDrop(e, index)}
+          >
+            {/* Drop indicator line */}
+            {dragOverIndex === index && (
+              <div className="h-[2px] bg-accent rounded-full mx-2 mb-2 transition-all" />
+            )}
+            <TaskCard
+              task={task}
+              showDate={bucket.key === 'nodate' || bucket.key === 'overdue' || bucket.key === 'later' || bucket.key === 'next7d'}
+              bucketKey={bucket.key}
+              isSelected={selectedIds.has(task._id)}
+              onDragStart={onDragStart}
+              onClick={(e) => onTaskClick(task._id, e)}
+              onComplete={() => onTaskComplete(task._id)}
+              onDelete={() => onTaskDelete(task._id)}
+              onRescheduleToday={() => onTaskReschedule(task._id, todayISO())}
+              onRescheduleTomorrow={() => onTaskReschedule(task._id, tomorrowISO())}
+              onRemoveDate={() => onTaskRemoveDate(task._id)}
+            />
           </div>
-        ) : (
-          bucket.tasks.map((task) => (
-            <TaskCard key={task._id} task={task} />
-          ))
-        )}
+        ))}
+        {/* End-of-column drop zone */}
+        <div
+          onDragOver={handleEndZoneDragOver}
+          onDrop={handleEndZoneDrop}
+          className="min-h-[8px]"
+        >
+          {dragOverIndex === bucket.tasks.length && bucket.tasks.length > 0 && (
+            <div className="h-[2px] bg-accent rounded-full mx-2 mb-1 transition-all" />
+          )}
+        </div>
+      </div>
+
+      {/* Drop indicator when empty and dragging over */}
+      {isDragOver && bucket.tasks.length === 0 && (
+        <div className="mx-1 h-12 rounded-xl border-2 border-dashed border-accent/30 flex items-center justify-center">
+          <span className="text-[11px] text-accent/50">Drop here</span>
+        </div>
+      )}
+
+      {/* Inline add task */}
+      <div className="mt-1 px-1">
+        <InlineAddTask defaultDate={bucket.defaultDate} />
       </div>
     </div>
   );
@@ -353,8 +1051,280 @@ function BucketColumn({ bucket }: BucketColumnProps) {
 
 export function TasksBucketed() {
   const tasks = useQuery(api.tasks.list, { status: 'todo' });
+  const updateTask = useMutation(api.tasks.update);
+  const completeTaskMut = useMutation(api.tasks.complete);
+  const removeTaskMut = useMutation(api.tasks.remove);
+  const [dragOverKey, setDragOverKey] = useState<string | null>(null);
+  const [selectedTaskId, setSelectedTaskId] = useState<Id<'tasks'> | null>(null);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const lastSelectedIdRef = useRef<string | null>(null);
+  const dragTaskIdRef = useRef<string | null>(null);
 
-  if (!tasks) return <div className="text-text-muted">Loading...</div>;
+  // Build a flat ordered list of task IDs for shift-select range
+  const allTaskIds = tasks ? tasks.map((t) => t._id as string) : [];
+
+  // Clear selection on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && selectedIds.size > 0) {
+        setSelectedIds(new Set());
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [selectedIds.size]);
+
+  const handleTaskClick = useCallback((taskId: Id<'tasks'>, e: React.MouseEvent) => {
+    if (e.metaKey || e.ctrlKey) {
+      // Toggle individual selection
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(taskId)) {
+          next.delete(taskId);
+        } else {
+          next.add(taskId);
+        }
+        return next;
+      });
+      lastSelectedIdRef.current = taskId;
+    } else if (e.shiftKey && lastSelectedIdRef.current) {
+      // Range select
+      const startIdx = allTaskIds.indexOf(lastSelectedIdRef.current);
+      const endIdx = allTaskIds.indexOf(taskId);
+      if (startIdx !== -1 && endIdx !== -1) {
+        const from = Math.min(startIdx, endIdx);
+        const to = Math.max(startIdx, endIdx);
+        setSelectedIds((prev) => {
+          const next = new Set(prev);
+          for (let i = from; i <= to; i++) {
+            next.add(allTaskIds[i]);
+          }
+          return next;
+        });
+      }
+    } else if (selectedIds.size > 0) {
+      // If already in selection mode, toggle
+      setSelectedIds((prev) => {
+        const next = new Set(prev);
+        if (next.has(taskId)) {
+          next.delete(taskId);
+        } else {
+          next.add(taskId);
+        }
+        return next;
+      });
+      lastSelectedIdRef.current = taskId;
+    } else {
+      // Normal click - open detail modal
+      setSelectedTaskId(taskId);
+    }
+  }, [allTaskIds, selectedIds.size]);
+
+  // ── Bulk action handlers ──────────────────────────
+
+  const handleBulkComplete = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    setSelectedIds(new Set());
+    for (const id of ids) {
+      try {
+        await completeTaskMut({ id: id as Id<'tasks'> });
+      } catch (err) {
+        console.error('Failed to complete task:', err);
+      }
+    }
+  }, [selectedIds, completeTaskMut]);
+
+  const handleBulkRescheduleToday = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    const today = todayISO();
+    setSelectedIds(new Set());
+    for (const id of ids) {
+      try {
+        await updateTask({ id: id as Id<'tasks'>, dueDate: today });
+      } catch (err) {
+        console.error('Failed to reschedule task:', err);
+      }
+    }
+  }, [selectedIds, updateTask]);
+
+  const handleBulkRescheduleTomorrow = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    const tomorrow = tomorrowISO();
+    setSelectedIds(new Set());
+    for (const id of ids) {
+      try {
+        await updateTask({ id: id as Id<'tasks'>, dueDate: tomorrow });
+      } catch (err) {
+        console.error('Failed to reschedule task:', err);
+      }
+    }
+  }, [selectedIds, updateTask]);
+
+  const handleBulkRemoveDate = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    setSelectedIds(new Set());
+    for (const id of ids) {
+      try {
+        await updateTask({ id: id as Id<'tasks'>, dueDate: '' });
+      } catch (err) {
+        console.error('Failed to remove task date:', err);
+      }
+    }
+  }, [selectedIds, updateTask]);
+
+  const handleBulkDelete = useCallback(async () => {
+    const ids = Array.from(selectedIds);
+    setSelectedIds(new Set());
+    for (const id of ids) {
+      try {
+        await removeTaskMut({ id: id as Id<'tasks'> });
+      } catch (err) {
+        console.error('Failed to delete task:', err);
+      }
+    }
+  }, [selectedIds, removeTaskMut]);
+
+  const handleTaskComplete = useCallback(async (taskId: Id<'tasks'>) => {
+    try {
+      await completeTaskMut({ id: taskId });
+    } catch (err) {
+      console.error('Failed to complete task:', err);
+    }
+  }, [completeTaskMut]);
+
+  const handleTaskDelete = useCallback(async (taskId: Id<'tasks'>) => {
+    try {
+      await removeTaskMut({ id: taskId });
+    } catch (err) {
+      console.error('Failed to delete task:', err);
+    }
+  }, [removeTaskMut]);
+
+  const handleTaskReschedule = useCallback(async (taskId: Id<'tasks'>, date: string) => {
+    try {
+      await updateTask({ id: taskId, dueDate: date });
+    } catch (err) {
+      console.error('Failed to reschedule task:', err);
+    }
+  }, [updateTask]);
+
+  const handleTaskRemoveDate = useCallback(async (taskId: Id<'tasks'>) => {
+    try {
+      await updateTask({ id: taskId, dueDate: '' });
+    } catch (err) {
+      console.error('Failed to remove task date:', err);
+    }
+  }, [updateTask]);
+
+  const handleDragStart = useCallback((e: React.DragEvent, taskId: string, bucketKey: string) => {
+    dragTaskIdRef.current = taskId;
+    e.dataTransfer.effectAllowed = 'move';
+    e.dataTransfer.setData('text/plain', taskId);
+    e.dataTransfer.setData('application/x-source-bucket', bucketKey);
+    // Make the drag image slightly transparent
+    if (e.currentTarget instanceof HTMLElement) {
+      e.currentTarget.style.opacity = '0.5';
+      requestAnimationFrame(() => {
+        if (e.currentTarget instanceof HTMLElement) {
+          e.currentTarget.style.opacity = '1';
+        }
+      });
+    }
+  }, []);
+
+  const handleDragOver = useCallback((e: React.DragEvent, bucketKey: string) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    setDragOverKey(bucketKey);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    // Only clear if we are leaving the column entirely (not entering a child)
+    const relatedTarget = e.relatedTarget as Node | null;
+    if (e.currentTarget instanceof HTMLElement && relatedTarget && e.currentTarget.contains(relatedTarget)) {
+      return;
+    }
+    setDragOverKey(null);
+  }, []);
+
+  const handleReorder = useCallback(async (taskId: Id<'tasks'>, targetIndex: number, bucket: TaskBucket) => {
+    const tasks = bucket.tasks;
+    // Find the current index of the dragged task
+    const currentIndex = tasks.findIndex((t) => t._id === taskId);
+    if (currentIndex === -1 || currentIndex === targetIndex) return;
+
+    // Adjust target index if dragging downward (since removing the item shifts indices)
+    const adjustedIndex = targetIndex > currentIndex ? targetIndex - 1 : targetIndex;
+    if (adjustedIndex === currentIndex) return;
+
+    // Calculate new position value
+    let newPosition: number;
+    // Build the list without the dragged task to determine neighbors
+    const withoutDragged = tasks.filter((t) => t._id !== taskId);
+
+    if (withoutDragged.length === 0) {
+      // Only task in column
+      return;
+    } else if (adjustedIndex === 0) {
+      // Dropping at the top
+      const firstPos = withoutDragged[0].position ?? 0;
+      newPosition = firstPos - 1;
+    } else if (adjustedIndex >= withoutDragged.length) {
+      // Dropping at the end
+      const lastPos = withoutDragged[withoutDragged.length - 1].position ?? 0;
+      newPosition = lastPos + 1;
+    } else {
+      // Dropping between two tasks
+      const prevPos = withoutDragged[adjustedIndex - 1].position ?? 0;
+      const nextPos = withoutDragged[adjustedIndex].position ?? 0;
+      newPosition = (prevPos + nextPos) / 2;
+    }
+
+    try {
+      await updateTask({ id: taskId, position: newPosition });
+    } catch (err) {
+      console.error('Failed to reorder task:', err);
+    }
+  }, [updateTask]);
+
+  const handleDrop = useCallback(async (e: React.DragEvent, bucket: TaskBucket) => {
+    e.preventDefault();
+    setDragOverKey(null);
+
+    const taskId = e.dataTransfer.getData('text/plain');
+    if (!taskId) return;
+
+    // If same-column drop, it's handled by BucketColumn's handleTaskDrop
+    const sourceBucket = e.dataTransfer.getData('application/x-source-bucket');
+    if (sourceBucket === bucket.key) return;
+
+    // Determine the new due date based on the bucket
+    let newDueDate: string;
+    if (bucket.key === 'nodate') {
+      newDueDate = '';
+    } else if (bucket.defaultDate) {
+      newDueDate = bucket.defaultDate;
+    } else {
+      // "later" bucket has no defaultDate -- don't change
+      return;
+    }
+
+    try {
+      await updateTask({ id: taskId as Id<'tasks'>, dueDate: newDueDate });
+    } catch (err) {
+      console.error('Failed to move task:', err);
+    }
+  }, [updateTask]);
+
+  if (!tasks) {
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-16 rounded-xl bg-surface animate-pulse" />
+        ))}
+      </div>
+    );
+  }
 
   const buckets = bucketTasks(tasks);
 
@@ -362,23 +1332,58 @@ export function TasksBucketed() {
     <div className="max-w-none space-y-6">
       {/* Header */}
       <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight text-text">
-            Tasks{' '}
-            <span className="text-text-muted font-normal">[ {tasks.length} ]</span>
-          </h1>
-        </div>
-        <TaskForm />
+        <h1 className="text-2xl font-bold tracking-tight text-text">
+          Tasks
+        </h1>
+        <span className="text-sm text-text-muted tabular-nums">{tasks.length} tasks</span>
       </div>
 
       {/* Column layout */}
-      <div className="overflow-x-auto pb-4">
-        <div className="flex gap-3" style={{ minWidth: 'max-content' }}>
+      <div className="overflow-x-auto pb-4 -mx-2 px-2">
+        <div className="flex gap-4" style={{ minWidth: 'max-content' }}>
           {buckets.map((bucket) => (
-            <BucketColumn key={bucket.key} bucket={bucket} />
+            <BucketColumn
+              key={bucket.key}
+              bucket={bucket}
+              dragOverKey={dragOverKey}
+              selectedIds={selectedIds}
+              onDragStart={handleDragStart}
+              onDragOver={handleDragOver}
+              onDragLeave={handleDragLeave}
+              onDrop={handleDrop}
+              onReorder={handleReorder}
+              onTaskClick={handleTaskClick}
+              onTaskComplete={handleTaskComplete}
+              onTaskDelete={handleTaskDelete}
+              onTaskReschedule={handleTaskReschedule}
+              onTaskRemoveDate={handleTaskRemoveDate}
+            />
           ))}
         </div>
       </div>
+
+      {/* Bulk action bar */}
+      {selectedIds.size > 0 && (
+        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-surface border border-border rounded-xl shadow-2xl px-5 py-3">
+          <span className="text-sm text-text font-medium">{selectedIds.size} selected</span>
+          <div className="h-4 w-px bg-border" />
+          <button onClick={() => void handleBulkComplete()} className="text-sm text-text-muted hover:text-success transition-colors">Complete</button>
+          <button onClick={() => void handleBulkRescheduleToday()} className="text-sm text-text-muted hover:text-accent transition-colors">&rarr; Today</button>
+          <button onClick={() => void handleBulkRescheduleTomorrow()} className="text-sm text-text-muted hover:text-accent transition-colors">&rarr; Tomorrow</button>
+          <button onClick={() => void handleBulkRemoveDate()} className="text-sm text-text-muted hover:text-warning transition-colors">Remove date</button>
+          <button onClick={() => void handleBulkDelete()} className="text-sm text-text-muted hover:text-danger transition-colors">Delete</button>
+          <div className="h-4 w-px bg-border" />
+          <button onClick={() => setSelectedIds(new Set())} className="text-sm text-text-muted hover:text-text transition-colors">Clear</button>
+        </div>
+      )}
+
+      {/* Task detail modal */}
+      {selectedTaskId && (
+        <TaskDetailModal
+          taskId={selectedTaskId}
+          onClose={() => setSelectedTaskId(null)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/sections/tasks-by-goal.tsx
+++ b/web/src/components/sections/tasks-by-goal.tsx
@@ -59,7 +59,7 @@ export function TasksByGoal() {
   }
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           Tasks by Goal

--- a/web/src/components/sections/tasks-flat.tsx
+++ b/web/src/components/sections/tasks-flat.tsx
@@ -13,7 +13,7 @@ export function TasksFlat() {
   }
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           All Tasks

--- a/web/src/components/sections/tasks-kanban.tsx
+++ b/web/src/components/sections/tasks-kanban.tsx
@@ -22,7 +22,7 @@ export function TasksKanban() {
   const totalCount = todoTasks.length + doneTasks.length;
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-center justify-between">
         <span className="text-xs font-bold uppercase tracking-widest text-text-muted">
           Kanban Board

--- a/web/src/components/sections/tasks-today.tsx
+++ b/web/src/components/sections/tasks-today.tsx
@@ -12,7 +12,7 @@ export function TasksToday() {
   }
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Today&apos;s Tasks

--- a/web/src/components/sections/thoughts-list.tsx
+++ b/web/src/components/sections/thoughts-list.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { Button } from '@/components/ui/button';
-import type { Doc } from '../../../../../convex/_generated/dataModel';
+import { ThoughtDetailModal } from '@/components/thought-detail-modal';
+import type { Doc } from '@/lib/convex-api';
 
 type Thought = Doc<'thoughts'>;
 
@@ -32,6 +33,25 @@ function ThoughtAddForm({ onDone }: { onDone?: () => void }) {
 
   const createThought = useMutation(api.thoughts.create);
 
+  function closeModal() {
+    setOpen(false);
+    setTitle('');
+    setContent('');
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     if (!content.trim()) return;
@@ -43,9 +63,7 @@ function ThoughtAddForm({ onDone }: { onDone?: () => void }) {
       };
       if (title.trim()) args.title = title.trim();
       await createThought(args);
-      setTitle('');
-      setContent('');
-      setOpen(false);
+      closeModal();
       onDone?.();
     } catch (err) {
       console.error('Failed to create thought:', err);
@@ -63,52 +81,65 @@ function ThoughtAddForm({ onDone }: { onDone?: () => void }) {
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="rounded-lg border border-border bg-surface p-4 space-y-3"
+    <div
+      className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+      onClick={closeModal}
     >
-      <div>
-        <label className="mb-1 block text-xs font-medium text-text-muted">
-          Title (optional)
-        </label>
-        <input
-          type="text"
-          placeholder="Give it a title, or leave blank"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          autoFocus
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
-        />
+      <div
+        className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg p-6 space-y-4 animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text">New Thought</h2>
+          <button
+            type="button"
+            onClick={closeModal}
+            className="text-text-muted hover:text-text transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-muted">
+              Title (optional)
+            </label>
+            <input
+              type="text"
+              placeholder="Give it a title, or leave blank"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              autoFocus
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-xs font-medium text-text-muted">
+              Content
+            </label>
+            <textarea
+              placeholder="What are you thinking about?"
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              rows={4}
+              className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
+            />
+          </div>
+          <div className="flex gap-2">
+            <Button type="submit" disabled={loading || !content.trim()}>
+              {loading ? 'Saving...' : 'Save Thought'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={closeModal}>
+              Cancel
+            </Button>
+          </div>
+        </form>
       </div>
-      <div>
-        <label className="mb-1 block text-xs font-medium text-text-muted">
-          Content
-        </label>
-        <textarea
-          placeholder="What are you thinking about?"
-          value={content}
-          onChange={(e) => setContent(e.target.value)}
-          rows={4}
-          className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
-        />
-      </div>
-      <div className="flex gap-2">
-        <Button type="submit" disabled={loading || !content.trim()}>
-          {loading ? 'Saving...' : 'Save Thought'}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={() => {
-            setOpen(false);
-            setTitle('');
-            setContent('');
-          }}
-        >
-          Cancel
-        </Button>
-      </div>
-    </form>
+    </div>
   );
 }
 
@@ -117,11 +148,13 @@ function ThoughtRow({
   index,
   expanded,
   onToggle,
+  onSelect,
 }: {
   thought: Thought;
   index: number;
   expanded: boolean;
   onToggle: () => void;
+  onSelect: (thought: Thought) => void;
 }) {
   const displayTitle = getDisplayTitle(thought);
 
@@ -129,7 +162,7 @@ function ThoughtRow({
     <div className="border-b border-border last:border-b-0">
       <button
         type="button"
-        onClick={onToggle}
+        onClick={() => onSelect(thought)}
         className="flex w-full items-start gap-3 px-4 py-3 text-left transition-colors hover:bg-surface/50"
       >
         {/* Index badge */}
@@ -173,6 +206,7 @@ function ThoughtRow({
 export function ThoughtsList() {
   const thoughts = useQuery(api.thoughts.list, {});
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
+  const [selectedThought, setSelectedThought] = useState<Thought | null>(null);
 
   function toggleExpanded(id: string) {
     setExpandedIds((prev) => {
@@ -186,7 +220,13 @@ export function ThoughtsList() {
     });
   }
 
-  if (!thoughts) return <div className="text-text-muted">Loading...</div>;
+  if (!thoughts) return (
+    <div className="space-y-3">
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="h-16 rounded-xl bg-surface animate-pulse" />
+      ))}
+    </div>
+  );
 
   return (
     <div className="max-w-none space-y-6">
@@ -201,10 +241,34 @@ export function ThoughtsList() {
 
       {/* List */}
       {thoughts.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-20">
-          <p className="text-base font-medium text-text">No thoughts yet</p>
-          <p className="mt-1 text-sm text-text-muted">
-            Capture what is on your mind.
+        <div className="space-y-4">
+          <div className="border border-dashed border-border/50 rounded-xl overflow-hidden">
+            {[
+              { title: "I've been thinking about...", hint: 'Click to expand' },
+              { title: 'Something that crossed my mind...', hint: 'Click to expand' },
+            ].map((ghost, idx) => (
+              <div
+                key={idx}
+                className="flex w-full items-start gap-3 px-4 py-3 opacity-40 border-b border-border/30 last:border-b-0"
+              >
+                <span className="mt-0.5 shrink-0 text-xs font-mono text-text-muted">
+                  [{String(idx + 1).padStart(2, '0')}]
+                </span>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-text-muted shrink-0">{'\u25B8'}</span>
+                    <span className="text-sm font-medium text-text-muted italic truncate">
+                      {ghost.title}
+                    </span>
+                  </div>
+                  <p className="mt-0.5 ml-5 text-xs text-text-muted/60">{ghost.hint}</p>
+                </div>
+                <span className="shrink-0 text-xs text-text-muted mt-0.5">Today</span>
+              </div>
+            ))}
+          </div>
+          <p className="text-center text-sm text-text-muted/70">
+            Record your first thought
           </p>
         </div>
       ) : (
@@ -216,9 +280,18 @@ export function ThoughtsList() {
               index={i}
               expanded={expandedIds.has(thought._id)}
               onToggle={() => toggleExpanded(thought._id)}
+              onSelect={setSelectedThought}
             />
           ))}
         </div>
+      )}
+
+      {/* Detail Modal */}
+      {selectedThought && (
+        <ThoughtDetailModal
+          thought={selectedThought}
+          onClose={() => setSelectedThought(null)}
+        />
       )}
     </div>
   );

--- a/web/src/components/sections/vision-board.tsx
+++ b/web/src/components/sections/vision-board.tsx
@@ -35,7 +35,7 @@ function AddImageForm({ onDone }: { onDone: () => void }) {
   }
 
   return (
-    <form onSubmit={handleSubmit} className="border border-border bg-surface p-4 space-y-3">
+    <form onSubmit={handleSubmit} className="border border-border rounded-xl bg-surface p-4 space-y-3">
       <input
         type="url"
         placeholder="Paste image URL..."
@@ -88,7 +88,7 @@ function ImageCard({
 
   return (
     <div
-      className="relative group border border-border overflow-hidden"
+      className="relative group border border-border rounded-xl overflow-hidden"
       onMouseEnter={() => setHovering(true)}
       onMouseLeave={() => setHovering(false)}
     >
@@ -145,7 +145,7 @@ export function VisionBoard() {
   }
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       {/* Header */}
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">

--- a/web/src/components/sections/weekly-plan.tsx
+++ b/web/src/components/sections/weekly-plan.tsx
@@ -8,7 +8,13 @@ export function WeeklyPlan() {
   const weeklyPlanResult = useQuery(api.weeklyPlans.list, { current: true });
 
   if (weeklyPlanResult === undefined) {
-    return <div className="text-text-muted">Loading...</div>;
+    return (
+      <div className="space-y-3">
+        {[1, 2, 3].map((i) => (
+          <div key={i} className="h-16 rounded-xl bg-surface animate-pulse" />
+        ))}
+      </div>
+    );
   }
 
   // When current: true, the API returns a single plan or null (not an array)
@@ -17,7 +23,7 @@ export function WeeklyPlan() {
     : weeklyPlanResult;
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl overflow-hidden">
       <div className="px-6 py-4 border-b border-border flex items-baseline justify-between">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">Weekly Plan</h2>
         {weeklyPlan && (

--- a/web/src/components/sections/weekly-review-form.tsx
+++ b/web/src/components/sections/weekly-review-form.tsx
@@ -61,9 +61,15 @@ function GoalHealthBadge({ goalId }: { goalId: Id<"goals"> }) {
   );
 }
 
+// ── Props ────────────────────────────────────────────
+
+interface WeeklyReviewFormProps {
+  onSaved?: () => void;
+}
+
 // ── Main component ───────────────────────────────────
 
-export function WeeklyReviewForm() {
+export function WeeklyReviewForm({ onSaved }: WeeklyReviewFormProps = {}) {
   const { start, end } = useMemo(() => getCurrentWeekRange(), []);
   const weekStartStr = toDateStr(start);
   const weekEndStr = toDateStr(end);
@@ -129,6 +135,7 @@ export function WeeklyReviewForm() {
         score: scoreNum,
       });
       setSaved(true);
+      onSaved?.();
     } finally {
       setSaving(false);
     }
@@ -136,7 +143,7 @@ export function WeeklyReviewForm() {
 
   if (saved) {
     return (
-      <div className="border border-border p-8 text-center">
+      <div className="border border-border rounded-xl p-8 text-center">
         <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="mx-auto mb-3 text-success">
           <polyline points="20 6 9 17 4 12" />
         </svg>
@@ -151,7 +158,7 @@ export function WeeklyReviewForm() {
   const isLoading = journals === undefined || goals === undefined;
 
   return (
-    <div className="border border-border">
+    <div className="border border-border rounded-xl">
       {/* Header */}
       <div className="px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
@@ -162,8 +169,8 @@ export function WeeklyReviewForm() {
       {isLoading ? (
         <div className="p-6">
           <div className="animate-pulse space-y-4">
-            <div className="h-20 bg-surface rounded" />
-            <div className="h-20 bg-surface rounded" />
+            <div className="h-20 bg-surface rounded-lg" />
+            <div className="h-20 bg-surface rounded-lg" />
           </div>
         </div>
       ) : (
@@ -193,7 +200,7 @@ export function WeeklyReviewForm() {
               onChange={(e) => setAdditionalHighlights(e.target.value)}
               placeholder="Add more highlights (one per line)..."
               rows={3}
-              className="w-full bg-surface border border-border px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
+              className="w-full bg-surface border border-border rounded-lg px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
             />
           </div>
 
@@ -207,7 +214,7 @@ export function WeeklyReviewForm() {
               onChange={(e) => setChallenges(e.target.value)}
               placeholder="What was difficult this week?"
               rows={3}
-              className="w-full bg-surface border border-border px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
+              className="w-full bg-surface border border-border rounded-lg px-4 py-3 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
             />
           </div>
 
@@ -220,7 +227,7 @@ export function WeeklyReviewForm() {
               <span className="text-xs text-text-muted block mb-3">Pre-filled from active goals:</span>
               <div className="space-y-4">
                 {goals.map((goal) => (
-                  <div key={goal._id} className="border border-border p-4">
+                  <div key={goal._id} className="border border-border rounded-lg p-4">
                     <div className="flex items-center justify-between gap-3 mb-2">
                       <span className="text-sm font-medium text-text">{goal.title}</span>
                       <GoalHealthBadge goalId={goal._id} />
@@ -232,7 +239,7 @@ export function WeeklyReviewForm() {
                       }
                       placeholder="Notes on progress..."
                       rows={2}
-                      className="w-full bg-bg border border-border px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
+                      className="w-full bg-bg border border-border rounded-lg px-3 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50 resize-none"
                     />
                   </div>
                 ))}
@@ -253,7 +260,7 @@ export function WeeklyReviewForm() {
                   value={p1}
                   onChange={(e) => setP1(e.target.value)}
                   placeholder="Most important thing next week"
-                  className="flex-1 bg-surface border border-border px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
+                  className="flex-1 bg-surface border border-border rounded-lg px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
                 />
               </div>
               <div className="flex items-center gap-3">
@@ -263,7 +270,7 @@ export function WeeklyReviewForm() {
                   value={p2}
                   onChange={(e) => setP2(e.target.value)}
                   placeholder="Second priority"
-                  className="flex-1 bg-surface border border-border px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
+                  className="flex-1 bg-surface border border-border rounded-lg px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
                 />
               </div>
               <div className="flex items-center gap-3">
@@ -273,7 +280,7 @@ export function WeeklyReviewForm() {
                   value={p3}
                   onChange={(e) => setP3(e.target.value)}
                   placeholder="Third priority"
-                  className="flex-1 bg-surface border border-border px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
+                  className="flex-1 bg-surface border border-border rounded-lg px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
                 />
               </div>
             </div>
@@ -291,7 +298,7 @@ export function WeeklyReviewForm() {
               value={score}
               onChange={(e) => setScore(e.target.value)}
               placeholder="How was this week?"
-              className="w-24 bg-surface border border-border px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
+              className="w-24 bg-surface border border-border rounded-lg px-4 py-2 text-sm text-text placeholder:text-text-muted/50 focus:outline-none focus:border-accent/50"
             />
           </div>
 
@@ -300,7 +307,7 @@ export function WeeklyReviewForm() {
             <button
               onClick={handleSave}
               disabled={saving || !score || parseInt(score, 10) < 1 || parseInt(score, 10) > 10}
-              className="px-6 py-2.5 text-sm font-bold uppercase tracking-wide bg-accent text-bg hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              className="px-6 py-2.5 text-sm font-bold uppercase tracking-wide bg-accent text-bg rounded-lg hover:bg-accent-hover transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
             >
               {saving ? 'Saving...' : 'Save Review'}
             </button>

--- a/web/src/components/sections/weekly-theme.tsx
+++ b/web/src/components/sections/weekly-theme.tsx
@@ -16,7 +16,7 @@ export function WeeklyTheme() {
   const plan = Array.isArray(weeklyPlan) ? weeklyPlan[0] ?? null : weeklyPlan;
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Weekly Theme

--- a/web/src/components/sections/wins-today.tsx
+++ b/web/src/components/sections/wins-today.tsx
@@ -16,7 +16,7 @@ export function WinsToday() {
   }
 
   return (
-    <div className="border border-border flex flex-col">
+    <div className="border border-border rounded-xl overflow-hidden flex flex-col">
       <div className="flex items-baseline justify-between px-6 py-4 border-b border-border">
         <h2 className="text-sm font-bold text-text uppercase tracking-wide">
           Wins

--- a/web/src/components/slash-command-menu.tsx
+++ b/web/src/components/slash-command-menu.tsx
@@ -1,0 +1,214 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+export interface SlashCommand {
+  id: string;
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  action: () => void;
+}
+
+interface SlashCommandState {
+  menuVisible: boolean;
+  filteredCommands: SlashCommand[];
+  selectedIndex: number;
+  query: string;
+}
+
+interface UseSlashCommandsReturn extends SlashCommandState {
+  handleInputChange: (value: string, cursorPosition: number) => void;
+  handleKeyDown: (e: React.KeyboardEvent) => boolean;
+  dismiss: () => void;
+  selectCommand: (index: number) => void;
+}
+
+export function useSlashCommands(
+  commands: SlashCommand[],
+  onTextChange?: (cleanedText: string) => void
+): UseSlashCommandsReturn {
+  const [state, setState] = useState<SlashCommandState>({
+    menuVisible: false,
+    filteredCommands: [],
+    selectedIndex: 0,
+    query: '',
+  });
+
+  const slashStartRef = useRef<number>(-1);
+
+  const dismiss = useCallback(() => {
+    setState({
+      menuVisible: false,
+      filteredCommands: [],
+      selectedIndex: 0,
+      query: '',
+    });
+    slashStartRef.current = -1;
+  }, []);
+
+  const handleInputChange = useCallback(
+    (value: string, cursorPosition: number) => {
+      // Find the last "/" before cursor that starts a command
+      const textBeforeCursor = value.slice(0, cursorPosition);
+      const lastSlashIndex = textBeforeCursor.lastIndexOf('/');
+
+      if (lastSlashIndex === -1 || (lastSlashIndex > 0 && textBeforeCursor[lastSlashIndex - 1] !== ' ')) {
+        // No slash, or slash is not at start or after a space
+        if (lastSlashIndex === -1 || lastSlashIndex > 0) {
+          dismiss();
+          return;
+        }
+      }
+
+      const query = textBeforeCursor.slice(lastSlashIndex + 1).toLowerCase();
+
+      // Check if there's a space in the query (means user moved past the command)
+      if (query.includes(' ')) {
+        dismiss();
+        return;
+      }
+
+      slashStartRef.current = lastSlashIndex;
+
+      const filtered = commands.filter(
+        (cmd) =>
+          cmd.id.toLowerCase().includes(query) ||
+          cmd.label.toLowerCase().includes(query)
+      );
+
+      setState({
+        menuVisible: true,
+        filteredCommands: filtered,
+        selectedIndex: 0,
+        query,
+      });
+    },
+    [commands, dismiss]
+  );
+
+  const selectCommand = useCallback(
+    (index: number) => {
+      const cmd = state.filteredCommands[index];
+      if (!cmd) return;
+
+      // Remove the slash command text from input
+      if (onTextChange) {
+        onTextChange('');
+      }
+
+      cmd.action();
+      dismiss();
+    },
+    [state.filteredCommands, dismiss, onTextChange]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent): boolean => {
+      if (!state.menuVisible) return false;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        setState((prev) => ({
+          ...prev,
+          selectedIndex: Math.min(prev.selectedIndex + 1, prev.filteredCommands.length - 1),
+        }));
+        return true;
+      }
+
+      if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        setState((prev) => ({
+          ...prev,
+          selectedIndex: Math.max(prev.selectedIndex - 1, 0),
+        }));
+        return true;
+      }
+
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault();
+        selectCommand(state.selectedIndex);
+        return true;
+      }
+
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        dismiss();
+        return true;
+      }
+
+      return false;
+    },
+    [state.menuVisible, state.selectedIndex, selectCommand, dismiss]
+  );
+
+  return {
+    ...state,
+    handleInputChange,
+    handleKeyDown,
+    dismiss,
+    selectCommand,
+  };
+}
+
+// ── Slash Command Menu Component ─────────────────────
+
+interface SlashCommandMenuProps {
+  commands: SlashCommand[];
+  selectedIndex: number;
+  onSelect: (index: number) => void;
+}
+
+export function SlashCommandMenu({ commands, selectedIndex, onSelect }: SlashCommandMenuProps) {
+  const menuRef = useRef<HTMLDivElement>(null);
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Scroll selected item into view
+  useEffect(() => {
+    selectedRef.current?.scrollIntoView({ block: 'nearest' });
+  }, [selectedIndex]);
+
+  if (commands.length === 0) {
+    return (
+      <div
+        ref={menuRef}
+        className="w-64 rounded-xl border border-border bg-surface shadow-xl overflow-hidden"
+      >
+        <div className="px-3 py-3 text-xs text-text-muted text-center">
+          No matching commands
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      ref={menuRef}
+      className="w-64 max-h-64 overflow-y-auto rounded-xl border border-border bg-surface shadow-xl"
+    >
+      {commands.map((cmd, idx) => (
+        <button
+          key={cmd.id}
+          ref={idx === selectedIndex ? selectedRef : undefined}
+          type="button"
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            onSelect(idx);
+          }}
+          className={`w-full flex items-center gap-2.5 px-3 py-2.5 text-left transition-colors ${
+            idx === selectedIndex ? 'bg-surface-hover' : ''
+          }`}
+        >
+          <span className="flex-shrink-0 w-5 h-5 flex items-center justify-center text-text-muted">
+            {cmd.icon}
+          </span>
+          <div className="flex-1 min-w-0">
+            <div className="text-sm text-text font-medium">/{cmd.id}</div>
+            <div className="text-xs text-text-muted truncate">{cmd.description}</div>
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/task-actions.tsx
+++ b/web/src/components/task-actions.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { Button } from '@/components/ui/button';
-import type { Id } from '../../../../convex/_generated/dataModel';
+import type { Id } from '@/lib/convex-api';
 
 export function TaskActions({
   taskId,

--- a/web/src/components/task-detail-modal.tsx
+++ b/web/src/components/task-detail-modal.tsx
@@ -1,0 +1,669 @@
+'use client';
+
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/lib/convex-api';
+import type { Id } from '@/lib/convex-api';
+import { cn } from '@/lib/utils';
+
+// ── Date helpers (shared with tasks-bucketed) ───────
+
+function todayISO(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function formatDateLabel(dateStr: string): string {
+  const d = new Date(dateStr + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function shortDate(dateStr: string | undefined | null): string {
+  if (!dateStr) return 'No date';
+  const d = new Date(dateStr + 'T00:00:00');
+  return d.toLocaleDateString('en-US', { day: 'numeric', month: 'short', year: 'numeric' });
+}
+
+function tomorrowISO(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 1);
+  return d.toISOString().slice(0, 10);
+}
+
+function nextMondayISO(): string {
+  const d = new Date();
+  const day = d.getDay();
+  const daysUntilMonday = day === 0 ? 1 : 8 - day;
+  d.setDate(d.getDate() + daysUntilMonday);
+  return d.toISOString().slice(0, 10);
+}
+
+function nextWeekISO(): string {
+  const d = new Date();
+  d.setDate(d.getDate() + 7);
+  return d.toISOString().slice(0, 10);
+}
+
+function toISO(year: number, month: number, day: number): string {
+  return `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
+}
+
+// ── Calendar Icon ───────────────────────────────────
+
+function CalendarIcon({ className }: { className?: string }) {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className={className}>
+      <rect x="3" y="4" width="18" height="18" rx="2" ry="2" />
+      <line x1="16" y1="2" x2="16" y2="6" />
+      <line x1="8" y1="2" x2="8" y2="6" />
+      <line x1="3" y1="10" x2="21" y2="10" />
+    </svg>
+  );
+}
+
+// ── Inline Calendar Date Picker ─────────────────────
+
+interface CalendarDatePickerProps {
+  currentDate: string | undefined;
+  onSelect: (date: string | null) => void;
+  onClose: () => void;
+}
+
+function CalendarDatePicker({ currentDate, onSelect, onClose }: CalendarDatePickerProps) {
+  const ref = useRef<HTMLDivElement>(null);
+
+  const todayStr = todayISO();
+  const todayDate = new Date(todayStr + 'T00:00:00');
+
+  const [viewYear, setViewYear] = useState(() => {
+    if (currentDate) {
+      const d = new Date(currentDate + 'T00:00:00');
+      return d.getFullYear();
+    }
+    return todayDate.getFullYear();
+  });
+  const [viewMonth, setViewMonth] = useState(() => {
+    if (currentDate) {
+      const d = new Date(currentDate + 'T00:00:00');
+      return d.getMonth();
+    }
+    return todayDate.getMonth();
+  });
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onClose();
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [onClose]);
+
+  const goToPrevMonth = () => {
+    if (viewMonth === 0) {
+      setViewMonth(11);
+      setViewYear(viewYear - 1);
+    } else {
+      setViewMonth(viewMonth - 1);
+    }
+  };
+
+  const goToNextMonth = () => {
+    if (viewMonth === 11) {
+      setViewMonth(0);
+      setViewYear(viewYear + 1);
+    } else {
+      setViewMonth(viewMonth + 1);
+    }
+  };
+
+  const goToToday = () => {
+    setViewYear(todayDate.getFullYear());
+    setViewMonth(todayDate.getMonth());
+  };
+
+  const firstDayOfMonth = new Date(viewYear, viewMonth, 1);
+  let startDow = firstDayOfMonth.getDay() - 1;
+  if (startDow < 0) startDow = 6;
+
+  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  const daysInPrevMonth = new Date(viewYear, viewMonth, 0).getDate();
+
+  const calendarDays: Array<{ day: number; month: number; year: number; isCurrentMonth: boolean }> = [];
+
+  for (let i = startDow - 1; i >= 0; i--) {
+    const prevMonth = viewMonth === 0 ? 11 : viewMonth - 1;
+    const prevYear = viewMonth === 0 ? viewYear - 1 : viewYear;
+    calendarDays.push({ day: daysInPrevMonth - i, month: prevMonth, year: prevYear, isCurrentMonth: false });
+  }
+
+  for (let d = 1; d <= daysInMonth; d++) {
+    calendarDays.push({ day: d, month: viewMonth, year: viewYear, isCurrentMonth: true });
+  }
+
+  const remaining = 7 - (calendarDays.length % 7);
+  if (remaining < 7) {
+    const nextMonth = viewMonth === 11 ? 0 : viewMonth + 1;
+    const nextYear = viewMonth === 11 ? viewYear + 1 : viewYear;
+    for (let d = 1; d <= remaining; d++) {
+      calendarDays.push({ day: d, month: nextMonth, year: nextYear, isCurrentMonth: false });
+    }
+  }
+
+  const monthLabel = new Date(viewYear, viewMonth, 1).toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+  const weekDays = ['Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa', 'Su'];
+
+  const quickOptions = [
+    { label: 'Today', date: todayISO(), icon: '☀' },
+    { label: 'Tomorrow', date: tomorrowISO(), icon: '→' },
+    { label: 'Next Monday', date: nextMondayISO(), icon: '📅' },
+    { label: 'Next Week', date: nextWeekISO(), icon: '⏭' },
+    { label: 'No Date', date: null, icon: '✕' },
+  ];
+
+  return (
+    <div
+      ref={ref}
+      className="absolute z-50 top-full left-0 mt-1 w-[280px] border border-border bg-surface rounded-xl shadow-xl overflow-hidden"
+      onClick={(e) => e.stopPropagation()}
+    >
+      <div className="flex items-center justify-between px-3 pt-3 pb-2">
+        <button
+          type="button"
+          onClick={goToPrevMonth}
+          className="p-1 rounded-md text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+          aria-label="Previous month"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="15 18 9 12 15 6" />
+          </svg>
+        </button>
+        <div className="flex items-center gap-2">
+          <span className="text-xs font-semibold text-text">{monthLabel}</span>
+          <button
+            type="button"
+            onClick={goToToday}
+            className="text-[10px] text-text-muted hover:text-accent px-1.5 py-0.5 rounded-md hover:bg-surface-hover transition-colors"
+          >
+            Today
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={goToNextMonth}
+          className="p-1 rounded-md text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+          aria-label="Next month"
+        >
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <polyline points="9 18 15 12 9 6" />
+          </svg>
+        </button>
+      </div>
+
+      <div className="grid grid-cols-7 px-3 pb-1">
+        {weekDays.map((wd) => (
+          <div key={wd} className="text-center text-[10px] font-medium text-text-muted/50 py-1">
+            {wd}
+          </div>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-7 px-3 pb-2">
+        {calendarDays.map((cd, idx) => {
+          const dateStr = toISO(cd.year, cd.month, cd.day);
+          const isToday = dateStr === todayStr;
+          const isSelected = dateStr === currentDate;
+
+          return (
+            <button
+              key={idx}
+              type="button"
+              onClick={() => onSelect(dateStr)}
+              className={cn(
+                'h-8 w-full flex items-center justify-center text-[11px] rounded-lg transition-all duration-100',
+                !cd.isCurrentMonth && 'text-text-muted/25',
+                cd.isCurrentMonth && !isToday && !isSelected && 'text-text hover:bg-surface-hover',
+                isToday && !isSelected && 'text-accent font-bold bg-accent/10',
+                isSelected && 'bg-accent text-bg font-bold',
+              )}
+            >
+              {cd.day}
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="border-t border-border/40" />
+
+      <div className="p-2 space-y-0.5">
+        {quickOptions.map((opt) => {
+          const isActive = opt.date === (currentDate ?? null);
+          return (
+            <button
+              key={opt.label}
+              type="button"
+              onClick={() => onSelect(opt.date)}
+              className={cn(
+                'w-full text-left px-3 py-1.5 text-xs rounded-lg transition-colors flex items-center gap-2',
+                isActive ? 'bg-accent/10 text-accent font-medium' : 'text-text hover:bg-surface-hover',
+              )}
+            >
+              <span className="text-[11px] w-4 text-center opacity-60">{opt.icon}</span>
+              <span>{opt.label}</span>
+              {opt.date && (
+                <span className="ml-auto text-text-muted font-mono text-[10px]">
+                  {shortDate(opt.date)}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {currentDate && (
+        <>
+          <div className="border-t border-border/40" />
+          <div className="p-2">
+            <button
+              type="button"
+              onClick={() => onSelect(null)}
+              className="w-full text-center text-xs text-text-muted hover:text-danger py-1.5 rounded-lg hover:bg-surface-hover transition-colors"
+            >
+              Clear date
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Task Detail Modal ───────────────────────────────
+
+export function TaskDetailModal({ taskId, onClose }: { taskId: Id<'tasks'>; onClose: () => void }) {
+  const task = useQuery(api.tasks.get, { id: taskId });
+  const project = useQuery(api.projects.get, task?.projectId ? { id: task.projectId } : 'skip');
+  const goal = useQuery(api.goals.get, task?.goalId ? { id: task.goalId } : 'skip');
+
+  const updateTask = useMutation(api.tasks.update);
+  const completeTask = useMutation(api.tasks.complete);
+
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleValue, setTitleValue] = useState('');
+  const [notesValue, setNotesValue] = useState('');
+  const [completing, setCompleting] = useState(false);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
+
+  const titleInputRef = useRef<HTMLInputElement>(null);
+  const notesRef = useRef<HTMLTextAreaElement>(null);
+  const titleDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const notesDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const initializedRef = useRef(false);
+
+  // Initialize local state from task data
+  useEffect(() => {
+    if (task && !initializedRef.current) {
+      setTitleValue(task.title);
+      setNotesValue(task.notes ?? '');
+      initializedRef.current = true;
+    }
+  }, [task]);
+
+  // Reset initialized flag when taskId changes
+  useEffect(() => {
+    initializedRef.current = false;
+  }, [taskId]);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Prevent body scroll when modal is open
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, []);
+
+  // Auto-resize textarea
+  const autoResizeNotes = useCallback(() => {
+    if (notesRef.current) {
+      notesRef.current.style.height = 'auto';
+      notesRef.current.style.height = `${notesRef.current.scrollHeight}px`;
+    }
+  }, []);
+
+  useEffect(() => {
+    autoResizeNotes();
+  }, [notesValue, autoResizeNotes]);
+
+  // Debounced save for title
+  const saveTitleDebounced = useCallback(
+    (value: string) => {
+      if (titleDebounceRef.current) clearTimeout(titleDebounceRef.current);
+      titleDebounceRef.current = setTimeout(async () => {
+        if (value.trim() && task && value.trim() !== task.title) {
+          try {
+            await updateTask({ id: taskId, title: value.trim() });
+          } catch (err) {
+            console.error('Failed to update title:', err);
+          }
+        }
+      }, 1000);
+    },
+    [taskId, task, updateTask],
+  );
+
+  // Debounced save for notes
+  const saveNotesDebounced = useCallback(
+    (value: string) => {
+      if (notesDebounceRef.current) clearTimeout(notesDebounceRef.current);
+      notesDebounceRef.current = setTimeout(async () => {
+        if (task && value !== (task.notes ?? '')) {
+          try {
+            await updateTask({ id: taskId, notes: value });
+          } catch (err) {
+            console.error('Failed to update notes:', err);
+          }
+        }
+      }, 1000);
+    },
+    [taskId, task, updateTask],
+  );
+
+  // Save title on blur
+  const handleTitleBlur = useCallback(async () => {
+    setEditingTitle(false);
+    if (titleDebounceRef.current) clearTimeout(titleDebounceRef.current);
+    if (titleValue.trim() && task && titleValue.trim() !== task.title) {
+      try {
+        await updateTask({ id: taskId, title: titleValue.trim() });
+      } catch (err) {
+        console.error('Failed to update title:', err);
+      }
+    }
+  }, [titleValue, task, taskId, updateTask]);
+
+  // Save notes on blur
+  const handleNotesBlur = useCallback(async () => {
+    if (notesDebounceRef.current) clearTimeout(notesDebounceRef.current);
+    if (task && notesValue !== (task.notes ?? '')) {
+      try {
+        await updateTask({ id: taskId, notes: notesValue });
+      } catch (err) {
+        console.error('Failed to update notes:', err);
+      }
+    }
+  }, [notesValue, task, taskId, updateTask]);
+
+  const handleComplete = useCallback(async () => {
+    if (completing) return;
+    setCompleting(true);
+    try {
+      await completeTask({ id: taskId });
+      // Close modal after completing
+      setTimeout(() => onClose(), 300);
+    } catch (err) {
+      console.error('Failed to complete task:', err);
+      setCompleting(false);
+    }
+  }, [completeTask, completing, taskId, onClose]);
+
+  const handleDateSelect = useCallback(
+    async (date: string | null) => {
+      setDatePickerOpen(false);
+      try {
+        await updateTask({ id: taskId, dueDate: date ?? '' });
+      } catch (err) {
+        console.error('Failed to update date:', err);
+      }
+    },
+    [updateTask, taskId],
+  );
+
+  // Backdrop click
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  if (!task) {
+    return (
+      <div
+        className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+        onClick={handleBackdropClick}
+      >
+        <div className="rounded-2xl bg-surface border border-border shadow-2xl max-w-2xl w-full mx-4 p-8 animate-scale-in">
+          <div className="flex items-center justify-center">
+            <div className="h-6 w-6 border-2 border-accent border-t-transparent rounded-full animate-spin" />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const dueDate = task.dueDate ?? null;
+  const isOverdue = dueDate ? dueDate < todayISO() : false;
+  const isDone = task.status === 'done';
+  const createdDate = new Date(task._creationTime).toLocaleDateString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="rounded-2xl bg-surface border border-border shadow-2xl max-w-2xl w-full mx-4 flex flex-col max-h-[80vh] overflow-hidden animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-end px-4 py-3 border-b border-border/50">
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex flex-1 min-h-0">
+          {/* Left panel -- content */}
+          <div className="flex-[3] p-6 overflow-y-auto">
+            <div className="flex items-start gap-3">
+              {/* Checkbox */}
+              <button
+                type="button"
+                onClick={handleComplete}
+                disabled={completing || isDone}
+                className={cn(
+                  'mt-1 flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-[1.5px] transition-all duration-150',
+                  completing || isDone
+                    ? 'border-success bg-success/20'
+                    : isOverdue
+                      ? 'border-danger/60 hover:border-danger hover:bg-danger/10'
+                      : 'border-text-muted/30 hover:border-accent hover:bg-accent/10',
+                )}
+                aria-label={isDone ? 'Task completed' : `Complete "${task.title}"`}
+              >
+                {(completing || isDone) && (
+                  <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" className="text-success">
+                    <polyline points="20 6 9 17 4 12" />
+                  </svg>
+                )}
+              </button>
+
+              {/* Title */}
+              <div className="flex-1 min-w-0">
+                {editingTitle ? (
+                  <input
+                    ref={titleInputRef}
+                    type="text"
+                    value={titleValue}
+                    onChange={(e) => {
+                      setTitleValue(e.target.value);
+                      saveTitleDebounced(e.target.value);
+                    }}
+                    onBlur={handleTitleBlur}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        (e.target as HTMLInputElement).blur();
+                      }
+                    }}
+                    className={cn(
+                      'w-full bg-transparent text-lg font-semibold text-text focus:outline-none',
+                      isDone && 'line-through text-text-muted',
+                    )}
+                    autoFocus
+                  />
+                ) : (
+                  <h2
+                    className={cn(
+                      'text-lg font-semibold text-text cursor-text hover:text-accent/80 transition-colors',
+                      isDone && 'line-through text-text-muted',
+                    )}
+                    onClick={() => {
+                      if (!isDone) {
+                        setEditingTitle(true);
+                        setTimeout(() => titleInputRef.current?.focus(), 0);
+                      }
+                    }}
+                  >
+                    {titleValue || task.title}
+                  </h2>
+                )}
+              </div>
+            </div>
+
+            {/* Notes / Description */}
+            <div className="mt-5 pl-8">
+              <textarea
+                ref={notesRef}
+                value={notesValue}
+                onChange={(e) => {
+                  setNotesValue(e.target.value);
+                  saveNotesDebounced(e.target.value);
+                  autoResizeNotes();
+                }}
+                onBlur={handleNotesBlur}
+                placeholder="Add notes..."
+                rows={3}
+                className="w-full bg-transparent text-sm text-text placeholder:text-text-muted/40 focus:outline-none resize-none leading-relaxed"
+              />
+            </div>
+          </div>
+
+          {/* Right panel -- metadata sidebar */}
+          <div className="flex-[2] border-l border-border bg-bg-subtle p-5 overflow-y-auto space-y-4">
+            {/* Date */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Date</span>
+              <div className="relative">
+                <button
+                  type="button"
+                  onClick={() => setDatePickerOpen((prev) => !prev)}
+                  className={cn(
+                    'flex items-center gap-2 w-full text-left text-sm rounded-lg px-2.5 py-2 transition-colors',
+                    isOverdue
+                      ? 'text-danger hover:bg-danger/10'
+                      : dueDate
+                        ? 'text-text hover:bg-surface-hover'
+                        : 'text-text-muted hover:bg-surface-hover',
+                  )}
+                >
+                  <CalendarIcon className={isOverdue ? 'text-danger' : 'opacity-50'} />
+                  <span>{dueDate ? formatDateLabel(dueDate) : 'No date'}</span>
+                </button>
+                {datePickerOpen && (
+                  <CalendarDatePicker
+                    currentDate={dueDate ?? undefined}
+                    onSelect={handleDateSelect}
+                    onClose={() => setDatePickerOpen(false)}
+                  />
+                )}
+              </div>
+            </div>
+
+            {/* Project */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Project</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-lg">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-50 shrink-0">
+                  <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z" />
+                </svg>
+                <span className={task.projectId ? 'text-text' : 'text-text-muted'}>
+                  {project?.title ?? (task.projectId ? 'Loading...' : 'No project')}
+                </span>
+              </div>
+            </div>
+
+            {/* Goal */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Goal</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-lg">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-50 shrink-0">
+                  <circle cx="12" cy="12" r="10" />
+                  <circle cx="12" cy="12" r="6" />
+                  <circle cx="12" cy="12" r="2" />
+                </svg>
+                <span className={task.goalId ? 'text-text' : 'text-text-muted'}>
+                  {goal?.title ?? (task.goalId ? 'Loading...' : 'No goal')}
+                </span>
+              </div>
+            </div>
+
+            {/* Status */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Status</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm rounded-lg">
+                <span
+                  className={cn(
+                    'h-2 w-2 rounded-full shrink-0',
+                    task.status === 'todo' && 'bg-accent',
+                    task.status === 'done' && 'bg-success',
+                    task.status === 'dropped' && 'bg-text-muted',
+                  )}
+                />
+                <span className="text-text capitalize">{task.status}</span>
+              </div>
+            </div>
+
+            {/* Created */}
+            <div className="space-y-1.5">
+              <span className="text-[11px] font-medium text-text-muted uppercase tracking-wider">Created</span>
+              <div className="flex items-center gap-2 px-2.5 py-2 text-sm text-text-muted rounded-lg">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-50 shrink-0">
+                  <circle cx="12" cy="12" r="10" />
+                  <polyline points="12 6 12 12 16 14" />
+                </svg>
+                <span>{createdDate}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/task-form.tsx
+++ b/web/src/components/task-form.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '@/lib/convex-api';
 import { Button } from '@/components/ui/button';
@@ -13,6 +13,26 @@ export function TaskForm({ onDone }: { onDone?: () => void }) {
   const [notes, setNotes] = useState('');
 
   const createTask = useMutation(api.tasks.create);
+
+  function closeModal() {
+    setOpen(false);
+    setTitle('');
+    setDueDate('');
+    setNotes('');
+  }
+
+  useEffect(() => {
+    if (!open) return;
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') closeModal();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [open]);
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -28,10 +48,7 @@ export function TaskForm({ onDone }: { onDone?: () => void }) {
 
       await createTask(args);
 
-      setTitle('');
-      setDueDate('');
-      setNotes('');
-      setOpen(false);
+      closeModal();
       onDone?.();
     } catch (err) {
       console.error('Failed to create task:', err);
@@ -49,51 +66,63 @@ export function TaskForm({ onDone }: { onDone?: () => void }) {
   }
 
   return (
-    <form
-      onSubmit={handleSubmit}
-      className="rounded-lg border border-border bg-surface p-4 space-y-3"
+    <div
+      className="fixed inset-0 z-50 flex items-start pt-[12vh] justify-center bg-black/50"
+      onClick={closeModal}
     >
-      <input
-        type="text"
-        placeholder="Task title"
-        value={title}
-        onChange={(e) => setTitle(e.target.value)}
-        autoFocus
-        className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
-      />
+      <div
+        className="bg-surface border border-border rounded-2xl shadow-2xl w-full max-w-lg p-6 space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold text-text">New Task</h2>
+          <button
+            type="button"
+            onClick={closeModal}
+            className="text-text-muted hover:text-text transition-colors"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
 
-      <input
-        type="date"
-        value={dueDate}
-        onChange={(e) => setDueDate(e.target.value)}
-        className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
-      />
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <input
+            type="text"
+            placeholder="Task title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            autoFocus
+            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none"
+          />
 
-      <textarea
-        placeholder="Notes (optional)"
-        value={notes}
-        onChange={(e) => setNotes(e.target.value)}
-        rows={2}
-        className="w-full rounded-md border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
-      />
+          <input
+            type="date"
+            value={dueDate}
+            onChange={(e) => setDueDate(e.target.value)}
+            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text focus:border-accent focus:outline-none"
+          />
 
-      <div className="flex gap-2">
-        <Button type="submit" disabled={loading || !title.trim()}>
-          {loading ? 'Adding...' : 'Add Task'}
-        </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={() => {
-            setOpen(false);
-            setTitle('');
-            setDueDate('');
-            setNotes('');
-          }}
-        >
-          Cancel
-        </Button>
+          <textarea
+            placeholder="Notes (optional)"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={2}
+            className="w-full rounded-lg border border-border bg-bg px-3 py-2 text-sm text-text placeholder:text-text-muted focus:border-accent focus:outline-none resize-none"
+          />
+
+          <div className="flex gap-2">
+            <Button type="submit" disabled={loading || !title.trim()}>
+              {loading ? 'Adding...' : 'Add Task'}
+            </Button>
+            <Button type="button" variant="ghost" onClick={closeModal}>
+              Cancel
+            </Button>
+          </div>
+        </form>
       </div>
-    </form>
+    </div>
   );
 }

--- a/web/src/components/thought-detail-modal.tsx
+++ b/web/src/components/thought-detail-modal.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/lib/convex-api';
+import type { Doc } from '@/lib/convex-api';
+
+export function ThoughtDetailModal({
+  thought,
+  onClose,
+}: {
+  thought: Doc<'thoughts'>;
+  onClose: () => void;
+}) {
+  const removeThought = useMutation(api.thoughts.remove);
+
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
+  // Close on Escape
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  // Prevent body scroll
+  useEffect(() => {
+    document.body.style.overflow = 'hidden';
+    return () => { document.body.style.overflow = ''; };
+  }, []);
+
+  const handleDelete = useCallback(async () => {
+    try {
+      await removeThought({ id: thought._id });
+      onClose();
+    } catch (err) {
+      console.error('Failed to delete thought:', err);
+    }
+  }, [removeThought, thought._id, onClose]);
+
+  const handleBackdropClick = useCallback((e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) onClose();
+  }, [onClose]);
+
+  const createdDate = new Date(thought._creationTime).toLocaleDateString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+
+  const displayTitle = thought.title && thought.title.trim().length > 0
+    ? thought.title
+    : null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="rounded-2xl bg-surface border border-border shadow-2xl max-w-lg w-full mx-4 flex flex-col max-h-[80vh] overflow-hidden animate-scale-in"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-end px-4 py-3 border-b border-border/50">
+          <button
+            type="button"
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-text-muted hover:text-text hover:bg-surface-hover transition-colors"
+            aria-label="Close"
+          >
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="flex-1 p-6 overflow-y-auto space-y-4">
+          {/* Title */}
+          {displayTitle && (
+            <h2 className="text-lg font-semibold text-text">{displayTitle}</h2>
+          )}
+
+          {/* Content */}
+          <div className="text-sm text-text leading-relaxed whitespace-pre-wrap">
+            {thought.content}
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="px-6 py-4 border-t border-border/50 flex items-center justify-between">
+          {/* Created date */}
+          <div className="flex items-center gap-2 text-xs text-text-muted">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="opacity-50 shrink-0">
+              <circle cx="12" cy="12" r="10" />
+              <polyline points="12 6 12 12 16 14" />
+            </svg>
+            <span>{createdDate}</span>
+          </div>
+
+          {/* Delete */}
+          {!confirmDelete ? (
+            <button
+              type="button"
+              onClick={() => setConfirmDelete(true)}
+              className="text-xs text-text-muted hover:text-danger py-1.5 px-3 rounded-lg hover:bg-surface-hover transition-colors"
+            >
+              Delete
+            </button>
+          ) : (
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleDelete}
+                className="text-xs font-medium text-danger bg-danger/10 hover:bg-danger/20 py-1.5 px-3 rounded-lg transition-colors"
+              >
+                Confirm
+              </button>
+              <button
+                type="button"
+                onClick={() => setConfirmDelete(false)}
+                className="text-xs text-text-muted hover:text-text py-1.5 px-3 rounded-lg hover:bg-surface-hover transition-colors"
+              >
+                Cancel
+              </button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/dashboard-config.tsx
+++ b/web/src/lib/dashboard-config.tsx
@@ -64,7 +64,7 @@ export function DashboardConfigProvider({ children }: { children: React.ReactNod
 
   // Ensure new pages from DEFAULT_NAV_ORDER are merged into existing configs
   const savedOrder = rawConfig?.navOrder ?? [...DEFAULT_NAV_ORDER];
-  const mergedOrder = savedOrder.filter((p) => p !== 'life-coach');
+  const mergedOrder = savedOrder.filter((p) => p !== 'life-coach' && p !== 'plan');
   for (const page of DEFAULT_NAV_ORDER) {
     if (page !== 'life-coach' && !mergedOrder.includes(page)) {
       mergedOrder.push(page);

--- a/web/src/lib/presets.ts
+++ b/web/src/lib/presets.ts
@@ -648,7 +648,7 @@ export const PAGE_PRESETS: Record<PageKey, Record<PresetKey, PagePreset>> = {
 export const ALL_PRESET_KEYS = ["default", "solopreneur", "content-creator", "developer", "executive", "minimalist", "journaler"];
 
 export const DEFAULT_NAV_ORDER: PageKey[] = [
-  "life-coach", "today", "tasks", "projects", "goals", "journal", "ideas", "thoughts", "plan", "reviews", "resources", "calendar",
+  "life-coach", "today", "tasks", "journal", "projects", "goals", "ideas", "thoughts", "resources", "reviews", "calendar",
 ];
 
 export function getPreset(page: PageKey, presetKey: string): PagePreset {


### PR DESCRIPTION
## Summary
- **Sidebar**: Notion-style collapsible sidebar with category headers (Daily/Work/Capture/Reflect), hover-to-expand, rounded styling
- **Font**: Default changed from Kefa/Satoshi to Geist (matching lifeos.zone)
- **Tasks**: Todoist-style cards with drag-drop, calendar date picker, inline editing, multi-select bulk actions, context menus, drag reorder, detail overlay modal
- **Today**: Google Calendar-style timeline with hourly grid, red now-line, drag tasks into schedule, resize/reposition events
- **Quick Add**: Redesigned dropdown (Task/Idea/Thought/Win/Reminder) with slash commands
- **Command Palette**: Enhanced Cmd+K with create/navigate/action modes
- **Detail Modals**: Overlay modals for tasks, ideas, thoughts, goals, projects (Notion-style)
- **All forms** now open as overlay modals instead of inline
- **Reviews**: Working inline weekly review, overdue/upcoming/completed distinctions
- **Schedules** (renamed from Calendar): Google Calendar weekly grid, reminders-only, legend
- **Empty States**: Inviting preview cards across all sections
- **Polish**: Rounded corners everywhere, smooth animations, loading skeletons, hover action menus, connected views (project/goal linked tasks)
- **Removed**: Plan tab, Life Coach tooltip, old font-mono usage

## Test plan
- [ ] Verify sidebar toggle, hover-to-expand, category grouping
- [ ] Test task drag-drop between columns and within columns
- [ ] Test task detail modal: edit title, notes, date, complete
- [ ] Test inline editing (double-click task title)
- [ ] Test multi-select (Cmd+click) and bulk actions
- [ ] Test right-click context menu on tasks
- [ ] Test Cmd+K command palette (create, navigate, action modes)
- [ ] Test slash commands in quick capture (/task, /idea, etc.)
- [ ] Test all form overlays: journal, idea, goal, task, thought, project
- [ ] Test priority assignment and reassignment on Today tab
- [ ] Test timeline drag-in, resize, reposition, drag-to-remove
- [ ] Test weekly review flow (Start button → inline form → save)
- [ ] Test Schedules tab: weekly grid, reminders, legend
- [ ] Verify empty states on all pages (tasks, journal, projects, ideas, thoughts, goals)
- [ ] Verify Geist font across all pages including settings
- [ ] Verify rounded corners on all section containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)