### PR TITLE
Skip login screen and auto-trigger Google OAuth when URL params are present

### DIFF
--- a/web/src/app/(auth)/login/page.tsx
+++ b/web/src/app/(auth)/login/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAuthActions } from "@convex-dev/auth/react";
-import { Authenticated, AuthLoading } from "convex/react";
+import { Authenticated, Unauthenticated, AuthLoading } from "convex/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect } from "react";
 import { LoadingScreen } from "@/components/loading-screen";
@@ -24,12 +24,30 @@ function RedirectToApp() {
   return null;
 }
 
+// Auto-trigger Google sign-in when URL params indicate the user came from the website
+function AutoSignIn() {
+  const searchParams = useSearchParams();
+  const { signIn } = useAuthActions();
+  useEffect(() => {
+    const hasSigninParam = searchParams.get('signin') !== null;
+    const hasPlanParam = searchParams.get('plan') !== null;
+    const hasBillingParam = searchParams.get('billing') !== null;
+    if (hasSigninParam || hasPlanParam || hasBillingParam) {
+      void signIn("google");
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  return null;
+}
+
 export default function LoginPage() {
   const { signIn } = useAuthActions();
 
   return (
     <>
       <StoreUrlPrefs />
+      <Unauthenticated>
+        <AutoSignIn />
+      </Unauthenticated>
       <Authenticated>
         <RedirectToApp />
       </Authenticated>

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -24,7 +24,11 @@ function GoToApp() {
 
 function GoToLogin() {
   const router = useRouter();
-  useEffect(() => { router.replace('/login'); }, [router]);
+  const searchParams = useSearchParams();
+  useEffect(() => {
+    const qs = searchParams.toString();
+    router.replace(qs ? `/login?${qs}` : '/login');
+  }, [router, searchParams]);
   return null;
 }
 


### PR DESCRIPTION
When users arrive at app.lifeos.zone with ?signin, ?plan, or ?billing params
(e.g. from the website's app button or pricing page), they now bypass the
login screen and go straight to Google OAuth. Query params are also preserved
when redirecting from / to /login.

https://claude.ai/code/session_01Frm8PcS1nuFssgub1FksLG