### PR TITLE
Remove shared AI billing keys from LifeAI prod

### DIFF
--- a/infra/Pulumi.prod.yaml
+++ b/infra/Pulumi.prod.yaml
@@ -17,8 +17,4 @@ config:
     secure: v1:hVJuezUxsTD0iM69:j3qhXqKbcnzNg/ORcciKSE1sXUz8vaEBfpUbAo7c7ief4Q90CLe5FL6jD7hSvVpH
   lifeos:gatewaySystemKey:
     secure: v1:Rfp+wfsSKuyI/j/o:Nh9iZu60wGm2PJtOEP2flMwB9j8vdDDz/g50ciAZO7jq2vxFKg1wc0ICQzLnwuZn
-  lifeos:anthropicApiKey:
-    secure: v1:2NpfOD9wbzZlAdyq:2RtP6rM8UEoHQAbpBPgEtI1OKC04eM8O2Qm3rAXfVrpU0cgYdYHMM+akyH6Z4ogsG+t8LVed4VkVpyyTZpx4ErnFxcnFCXHl9TgHod2CC72/qne0H9spS1cgsivmIaMz834oo6DAxdEsRKEPInUlXEruTzPs57Nb3+asyw==
-  lifeos:openaiApiKey:
-    secure: v1:5yXuaVyuG0onUwJ4:5HmfmRbh5CavYH7ELPuq2bOuGekgwWHY5fUzY1OfCIsatUtowv28flfXCGgYaNslcJn0LBiUmnapVmuiQIAgGCEoyozg8UQvCZv0Uht6HeO+lU0SSboSOlGhH7ldG6MdEW9JC4U5Xmux7jl84wKxo8ri55cYEnKynRvWxUYFfc11SjrrOVvTWXYvzpdG3VM1KpmDPAskcWvI56Rg9NOm7vAuYdNUS1hkXVCKckS4n64jJq56
 encryptionsalt: v1:F+Lr6Wq9yNo=:v1:zh5CqyFmdQce09u7:OUXJzIDTZ+RZdlwaAqeoWI6pPdlUAg==

--- a/infra/gateway.ts
+++ b/infra/gateway.ts
@@ -83,7 +83,7 @@ export function createGateway(
                 name: "CONVEX_SITE_URL",
                 value: backend.convexSiteUrl,
               },
-              {
+              ...(config.getSecret("anthropicApiKey") ? [{
                 name: "ANTHROPIC_API_KEY",
                 valueFrom: {
                   secretKeyRef: {
@@ -91,7 +91,7 @@ export function createGateway(
                     key: "anthropic-api-key",
                   },
                 },
-              },
+              }] : []),
               // OPENAI_API_KEY — enables Whisper audio transcription proxy (only if secret is provisioned)
               ...(config.getSecret("openaiApiKey") ? [{
                 name: "OPENAI_API_KEY",

--- a/infra/secrets.ts
+++ b/infra/secrets.ts
@@ -16,7 +16,7 @@ export function createSecrets(
     stringData: {
       "jwt-signing-key": config.requireSecret("jwtSigningKey"),
       "gateway-system-key": config.requireSecret("gatewaySystemKey"),
-      "anthropic-api-key": config.requireSecret("anthropicApiKey"),
+      ...(config.getSecret("anthropicApiKey") ? { "anthropic-api-key": config.requireSecret("anthropicApiKey") } : {}),
       ...(config.getSecret("openaiApiKey") ? { "openai-api-key": config.requireSecret("openaiApiKey") } : {}),
       ...(config.getSecret("googleApiKey") ? { "google-api-key": config.requireSecret("googleApiKey") } : {}),
     },

--- a/web/convex/deploymentSettings.ts
+++ b/web/convex/deploymentSettings.ts
@@ -98,6 +98,8 @@ export const saveSettings = mutation({
       google: "googleKeyLength",
       moonshot: "moonshotKeyLength",
       minimax: "minimaxKeyLength",
+      "telegram-bot": "telegramBotTokenLength",
+      "discord-bot": "discordBotTokenLength",
     };
     if (args.keysToDelete) {
       for (const provider of args.keysToDelete) {


### PR DESCRIPTION
This removes the shared OpenAI and Anthropic provider keys from the LifeAI Pulumi prod config and makes those Kubernetes secrets/env vars optional. It also lets deployment settings clear Telegram/Discord channel bot token metadata via keysToDelete, so a user bot can be disconnected instead of staying coupled to an old pod config.\n\nNotes:\n- This does not touch OperatorAI.\n- I could not apply the Pulumi/GKE or Convex prod cleanup from this VM because this environment has GitHub write access only, not the old LifeAI Pulumi/GCP/Convex admin credentials.\n- After merge/deploy, remove the matching live Kubernetes secrets and any GCP Secret Manager BYOK entries for Kemp's Telegram bot.